### PR TITLE
docs: set up Sphinx + GitHub Pages for charted.mrzk.io

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: docs
+
+on:
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv==0.5.20
+
+      - name: Install dependencies
+        run: uv pip install --system -e '.[docs]'
+
+      - name: Build docs
+        run: sphinx-build -b html docs docs/_build/html
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+charted.mrzk.io

--- a/docs/api/charts.rst
+++ b/docs/api/charts.rst
@@ -1,0 +1,22 @@
+Charts API
+==========
+
+.. automodule:: charted.charts.line
+   :members:
+   :undoc-members:
+   :no-index:
+
+.. automodule:: charted.charts.bar
+   :members:
+   :undoc-members:
+   :no-index:
+
+.. automodule:: charted.charts.column
+   :members:
+   :undoc-members:
+   :no-index:
+
+.. automodule:: charted.charts.scatter
+   :members:
+   :undoc-members:
+   :no-index:

--- a/docs/api/themes.rst
+++ b/docs/api/themes.rst
@@ -1,0 +1,6 @@
+Themes API
+==========
+
+.. automodule:: charted.utils.themes
+   :members:
+   :undoc-members:

--- a/docs/charts/bar.rst
+++ b/docs/charts/bar.rst
@@ -1,0 +1,26 @@
+Bar Charts
+==========
+
+.. image:: ../examples/bar.svg
+   :width: 100%
+
+Basic usage::
+
+   from charted.charts.bar import BarChart
+
+   chart = BarChart(data=[1, 2, 3], labels=["a", "b", "c"])
+   chart.html
+
+Multi-series (side-by-side)::
+
+   chart = BarChart(
+       data=[[1, 2, 3], [3, 2, 1]],
+       labels=["a", "b", "c"],
+   )
+
+.. image:: ../examples/bar_multi.svg
+   :width: 100%
+
+.. autoclass:: charted.charts.bar.BarChart
+   :members:
+   :undoc-members:

--- a/docs/charts/column.rst
+++ b/docs/charts/column.rst
@@ -1,0 +1,23 @@
+Column Charts
+=============
+
+.. image:: ../examples/column.svg
+   :width: 100%
+
+Basic usage::
+
+   from charted.charts.column import ColumnChart
+
+   chart = ColumnChart(data=[1, 2, 3], labels=["a", "b", "c"])
+   chart.html
+
+Stacked::
+
+   chart = ColumnChart(
+       data=[[1, 2, 3], [2, 3, 4]],
+       labels=["a", "b", "c"],
+   )
+
+.. autoclass:: charted.charts.column.ColumnChart
+   :members:
+   :undoc-members:

--- a/docs/charts/line.rst
+++ b/docs/charts/line.rst
@@ -1,0 +1,37 @@
+Line Charts
+===========
+
+.. image:: ../examples/line.svg
+   :width: 100%
+
+Basic usage::
+
+   from charted.charts.line import LineChart
+
+   chart = LineChart(data=[1, 2, 3], labels=["a", "b", "c"])
+   chart.html  # returns SVG string
+
+Multi-series::
+
+   chart = LineChart(
+       data=[[1, 2, 3], [3, 2, 1]],
+       labels=["a", "b", "c"],
+       series_names=["Series 1", "Series 2"],
+   )
+
+.. image:: ../examples/xy_line.svg
+   :width: 100%
+
+XY (scatter-line) with real x-values::
+
+   from charted.charts.line import LineChart
+
+   chart = LineChart(
+       x_data=[-3, -1, 0, 1, 3],
+       y_data=[9, 1, 0, 1, 9],
+       labels=["Jan", "Feb", "Mar", "Apr", "May"],
+   )
+
+.. autoclass:: charted.charts.line.LineChart
+   :members:
+   :undoc-members:

--- a/docs/charts/scatter.rst
+++ b/docs/charts/scatter.rst
@@ -1,0 +1,23 @@
+Scatter Charts
+==============
+
+.. image:: ../examples/scatter.svg
+   :width: 100%
+
+Basic usage::
+
+   from charted.charts.scatter import ScatterChart
+
+   chart = ScatterChart(x_data=[1, 2, 3], y_data=[1, 4, 9])
+   chart.html
+
+Multi-series::
+
+   chart = ScatterChart(
+       x_data=[[1, 2, 3], [2, 3, 4]],
+       y_data=[[1, 4, 9], [4, 9, 16]],
+   )
+
+.. autoclass:: charted.charts.scatter.ScatterChart
+   :members:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,14 +19,21 @@ author = "Andryo Marzuki"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.autodoc"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-
-# -- Options for HTML output -------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
-
-html_theme = "alabaster"
+html_theme = "furo"
 html_static_path = ["_static"]
+html_title = "charted"
+html_logo = "_static/charted-logo.png"
+html_theme_options = {
+    "sidebar_hide_name": True,
+}
+
+autodoc_member_order = "bysource"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,30 @@
-.. charted documentation master file, created by
-   sphinx-quickstart on Fri Jun  7 15:46:58 2024.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+charted
+=======
 
-Welcome to charted's documentation!
-===================================
+Zero-dependency SVG chart generator for Python. Simple interface, beautiful output.
+
+.. code-block:: bash
+
+   pip install charted
+
+.. image:: examples/line.svg
+   :width: 100%
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Charts
 
+   charts/line
+   charts/bar
+   charts/column
+   charts/scatter
 
+.. toctree::
+   :maxdepth: 1
+   :caption: API Reference
+
+   api/charts
+   api/themes
 
 Indices and tables
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
 ]
 docs = [
     "sphinx>=7.3.7",
+    "furo>=2024.1.29",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docs.yml` — builds Sphinx on every push to main, deploys to GitHub Pages
- `docs/CNAME` — sets custom domain to `charted.mrzk.io`
- Switch theme from alabaster → furo (modern, responsive)
- Add chart pages (line, bar, column, scatter) with examples and SVG previews
- Add API reference pages
- Add `furo` to `[project.optional-dependencies.docs]`

## After merging

1. Go to **Settings → Pages** in the repo, set source to **GitHub Actions**
2. Add a DNS CNAME record: `charted.mrzk.io` → `marzukia.github.io`
3. The workflow runs on merge and deploys automatically