### PR TITLE
Add MCP server for charted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ tests/diffs/*.png
 .DS_Store
 Thumbs.db
 *.cover
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -500,20 +500,12 @@ md = chart.to_markdown()
 pip install charted
 ```
 
-For PNG export support:
+Optional extras (these add dependencies — the core library stays zero-dep):
 ```sh
-pip install 'charted[png]'
-# or just: pip install cairosvg
-```
-
-For DuckDB integration (generate charts directly from SQL queries):
-```sh
-pip install 'charted[duckdb]'
-```
-
-For PNG visual testing (dev):
-```sh
-pip install 'charted[dev]'
+pip install 'charted[png]'     # PNG export via cairosvg
+pip install 'charted[mcp]'     # MCP server for AI agent integration
+pip install 'charted[duckdb]'  # generate charts from SQL queries
+pip install 'charted[dev]'     # dev tools including PNG visual testing
 ```
 
 ## PNG Export
@@ -528,6 +520,22 @@ chart.save("chart.png", scale=3) # PNG at 3x resolution
 ```
 
 PNG export requires `cairosvg`. If it's not installed, `save()` raises a helpful `ImportError` with install instructions.
+
+---
+
+## MCP Server (AI Agent Integration)
+
+Charted includes an MCP server so AI agents (Claude Code, Cursor, etc.) can generate charts without writing Python:
+
+```sh
+# Register with Claude Code
+claude mcp add charted -- charted-mcp
+
+# Or run standalone
+charted-mcp
+```
+
+Exposes tools: `create_chart`, `list_chart_types`, `list_themes`, `chart_from_csv`. Requires `pip install charted[mcp]`.
 
 ---
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,10 @@
+"""MCP Server for the charted SVG chart library."""
+
+__version__ = "0.1.0"
+
+
+def main():
+    """Entry point — defers mcp import to runtime."""
+    from mcp_server.server import run
+
+    run()

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running the MCP server via `python -m mcp_server`."""
+
+from mcp_server.server import main
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,219 @@
+"""MCP server for the charted SVG chart library.
+
+Exposes charted's chart generation as MCP tools that any AI agent can use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+from mcp_server.tools import (
+    handle_chart_from_csv,
+    handle_create_chart,
+    handle_list_chart_types,
+    handle_list_themes,
+)
+
+app = Server("charted-mcp")
+
+
+@app.list_tools()
+async def list_tools() -> list[Tool]:
+    """Return the list of tools exposed by this server."""
+    return [
+        Tool(
+            name="create_chart",
+            description=(
+                "Create an SVG chart from data. Returns SVG string, "
+                "HTML wrapper, or data URL."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "chart_type": {
+                        "type": "string",
+                        "enum": [
+                            "bar", "column", "line", "scatter", "pie",
+                            "radar", "area", "box", "histogram", "heatmap",
+                            "gantt", "auto",
+                        ],
+                        "description": "Chart type. 'auto' picks the best type from data shape.",
+                    },
+                    "data": {
+                        "type": ["array", "object"],
+                        "description": "Chart data. 1D array for single series, 2D for multi-series.",
+                    },
+                    "labels": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "X-axis category labels.",
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Chart title.",
+                    },
+                    "series_names": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Names for each data series (used in legend).",
+                    },
+                    "width": {
+                        "type": "number",
+                        "default": 500,
+                        "description": "Chart width in pixels.",
+                    },
+                    "height": {
+                        "type": "number",
+                        "default": 500,
+                        "description": "Chart height in pixels.",
+                    },
+                    "theme": {
+                        "type": ["string", "object"],
+                        "description": "Theme preset name or config object.",
+                    },
+                    "output_format": {
+                        "type": "string",
+                        "enum": ["svg", "html", "data_url"],
+                        "default": "svg",
+                        "description": "Output format.",
+                    },
+                    "save_path": {
+                        "type": "string",
+                        "description": "Optional file path to save the chart.",
+                    },
+                },
+                "required": ["chart_type", "data"],
+            },
+        ),
+        Tool(
+            name="list_chart_types",
+            description="List all supported chart types with descriptions.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="list_themes",
+            description="List available theme presets and color palettes.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="chart_from_csv",
+            description="Generate a chart directly from CSV text data.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "csv_data": {
+                        "type": "string",
+                        "description": "Raw CSV text (with header row).",
+                    },
+                    "chart_type": {
+                        "type": "string",
+                        "enum": [
+                            "bar", "column", "line", "scatter", "pie",
+                            "radar", "area", "box", "histogram", "heatmap",
+                            "auto",
+                        ],
+                        "default": "auto",
+                        "description": "Chart type.",
+                    },
+                    "x_column": {
+                        "type": "string",
+                        "description": "Column name for x-axis labels.",
+                    },
+                    "y_columns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Column names for y-axis data series.",
+                    },
+                    "title": {"type": "string"},
+                    "theme": {"type": ["string", "object"]},
+                    "output_format": {
+                        "type": "string",
+                        "enum": ["svg", "html", "data_url"],
+                        "default": "svg",
+                    },
+                    "save_path": {"type": "string"},
+                },
+                "required": ["csv_data"],
+            },
+        ),
+    ]
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    """Dispatch a tool call to the appropriate handler."""
+    try:
+        if name == "create_chart":
+            result = handle_create_chart(
+                chart_type=arguments["chart_type"],
+                data=arguments["data"],
+                labels=arguments.get("labels"),
+                title=arguments.get("title"),
+                series_names=arguments.get("series_names"),
+                width=arguments.get("width"),
+                height=arguments.get("height"),
+                theme=arguments.get("theme"),
+                output_format=arguments.get("output_format", "svg"),
+                save_path=arguments.get("save_path"),
+            )
+            return [TextContent(type="text", text=result)]
+
+        elif name == "list_chart_types":
+            result = handle_list_chart_types()
+            return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+        elif name == "list_themes":
+            result = handle_list_themes()
+            return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+        elif name == "chart_from_csv":
+            result = handle_chart_from_csv(
+                csv_data=arguments["csv_data"],
+                chart_type=arguments.get("chart_type", "auto"),
+                x_column=arguments.get("x_column"),
+                y_columns=arguments.get("y_columns"),
+                title=arguments.get("title"),
+                theme=arguments.get("theme"),
+                output_format=arguments.get("output_format", "svg"),
+                save_path=arguments.get("save_path"),
+            )
+            return [TextContent(type="text", text=result)]
+
+        else:
+            return [TextContent(
+                type="text",
+                text=f"Unknown tool: {name}",
+            )]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error: {e}")]
+
+
+async def _run():
+    """Run the MCP server over stdio."""
+    async with stdio_server() as (read_stream, write_stream):
+        await app.run(
+            read_stream,
+            write_stream,
+            app.create_initialization_options(),
+        )
+
+
+def run():
+    """Entry point for the charted-mcp server."""
+    asyncio.run(_run())
+
+
+main = run

--- a/mcp_server/tools.py
+++ b/mcp_server/tools.py
@@ -1,0 +1,275 @@
+"""Tool implementations for the charted MCP server.
+
+Each function handles one MCP tool call and returns the result
+in a format suitable for the MCP response.
+"""
+
+from __future__ import annotations
+
+import csv
+import inspect
+import io
+from typing import Any
+
+import charted
+from charted.themes.core import NAMED_PALETTES, Theme
+
+CHART_TYPE_MAP = {
+    "bar": "BarChart",
+    "column": "ColumnChart",
+    "line": "LineChart",
+    "scatter": "ScatterChart",
+    "pie": "PieChart",
+    "radar": "RadarChart",
+    "area": "AreaChart",
+    "box": "BoxPlot",
+    "histogram": "Histogram",
+    "heatmap": "HeatmapChart",
+    "gantt": "GanttChart",
+}
+
+CHART_DESCRIPTIONS = {
+    "bar": "Horizontal bar chart for comparing categories",
+    "column": "Vertical bar chart",
+    "line": "Line chart for trends over time",
+    "scatter": "XY scatter plot for correlation",
+    "pie": "Pie/donut chart for part-of-whole",
+    "radar": "Spider/radar chart for multivariate comparison",
+    "area": "Filled line chart for volume over time",
+    "box": "Box-and-whisker plot for distributions",
+    "histogram": "Frequency distribution of continuous data",
+    "heatmap": "Color-coded matrix for 2D data",
+    "gantt": "Timeline/schedule visualization",
+}
+
+
+def handle_create_chart(
+    chart_type: str,
+    data: Any,
+    labels: list[str] | None = None,
+    title: str | None = None,
+    series_names: list[str] | None = None,
+    width: float | None = None,
+    height: float | None = None,
+    theme: str | dict | None = None,
+    output_format: str = "svg",
+    save_path: str | None = None,
+) -> str:
+    """Create a chart and return it in the requested format.
+
+    Args:
+        chart_type: One of the supported chart types or "auto".
+        data: Chart data (1D or 2D array).
+        labels: X-axis category labels.
+        title: Chart title.
+        series_names: Names for each data series.
+        width: Chart width in pixels.
+        height: Chart height in pixels.
+        theme: Theme preset name or config dict.
+        output_format: One of "svg", "html", "data_url".
+        save_path: Optional file path to save the chart.
+
+    Returns:
+        Chart content as a string in the requested format.
+
+    Raises:
+        ValueError: If chart_type is invalid or data is empty.
+    """
+    # Build kwargs for the chart constructor
+    kwargs: dict[str, Any] = {}
+    if title is not None:
+        kwargs["title"] = title
+    if width is not None:
+        kwargs["width"] = width
+    if height is not None:
+        kwargs["height"] = height
+    if labels is not None:
+        kwargs["labels"] = labels
+    if series_names is not None:
+        kwargs["series_names"] = series_names
+    if theme is not None:
+        if isinstance(theme, str):
+            kwargs["theme"] = theme
+        elif isinstance(theme, dict):
+            kwargs["theme"] = Theme(**theme)
+
+    # Create chart
+    if chart_type == "auto":
+        chart = charted.auto(data, **kwargs)
+    elif chart_type in CHART_TYPE_MAP:
+        cls_name = CHART_TYPE_MAP[chart_type]
+        cls = getattr(charted, cls_name)
+        # Filter kwargs to valid params for this chart class
+        sig = inspect.signature(cls.__init__)
+        valid_params = set(sig.parameters.keys()) - {"self"}
+        filtered = {}
+        for k, v in kwargs.items():
+            if k in valid_params:
+                filtered[k] = v
+        # Map 'labels' to the correct param name
+        if "labels" not in valid_params and "labels" in kwargs:
+            if "x_labels" in valid_params:
+                filtered["x_labels"] = kwargs["labels"]
+        # Handle charts that use x_data/y_data instead of data
+        if "data" in valid_params:
+            chart = cls(data=data, **filtered)
+        elif "x_data" in valid_params and "y_data" in valid_params:
+            # ScatterChart style: expects x_data and y_data
+            if isinstance(data, list) and len(data) == 2 and isinstance(data[0], list):
+                chart = cls(x_data=data[0], y_data=data[1], **filtered)
+            else:
+                # Single series: use indices as x_data
+                chart = cls(
+                    x_data=list(range(len(data))),
+                    y_data=data,
+                    **filtered,
+                )
+        else:
+            chart = cls(data=data, **filtered)
+    else:
+        raise ValueError(
+            f"Invalid chart_type: {chart_type!r}. "
+            f"Must be one of: {list(CHART_TYPE_MAP.keys())} or 'auto'."
+        )
+
+    # Save if requested
+    if save_path:
+        chart.save(save_path)
+
+    # Return in requested format
+    if output_format == "html":
+        return chart.to_html()
+    elif output_format == "data_url":
+        return chart.to_base64()
+    else:
+        return chart.to_svg()
+
+
+def handle_list_chart_types() -> list[dict[str, str]]:
+    """Return list of available chart types with descriptions.
+
+    Returns:
+        List of dicts with 'type', 'class', and 'description' keys.
+    """
+    return [
+        {
+            "type": chart_type,
+            "class": CHART_TYPE_MAP[chart_type],
+            "description": CHART_DESCRIPTIONS[chart_type],
+        }
+        for chart_type in CHART_TYPE_MAP
+    ]
+
+
+def handle_list_themes() -> dict[str, Any]:
+    """Return available theme presets and palettes.
+
+    Returns:
+        Dict with 'presets', 'palettes', and 'usage_hint' keys.
+    """
+    # Built-in presets from Theme.from_preset
+    presets = ["light", "dark", "high-contrast"]
+    # Add any user-registered themes
+    registered = charted.list_themes()
+    presets = sorted(set(presets + registered))
+    palettes = sorted(NAMED_PALETTES.keys())
+    return {
+        "presets": presets,
+        "palettes": palettes,
+        "usage_hint": (
+            'Pass preset name as theme param, or use palette name in a '
+            'theme object: {"colors": "viridis", "background_color": "#1a1a2e"}'
+        ),
+    }
+
+
+def handle_chart_from_csv(
+    csv_data: str,
+    chart_type: str = "auto",
+    x_column: str | None = None,
+    y_columns: list[str] | None = None,
+    title: str | None = None,
+    theme: str | dict | None = None,
+    output_format: str = "svg",
+    save_path: str | None = None,
+) -> str:
+    """Generate a chart from CSV text data.
+
+    Parses the CSV, auto-detects numeric columns, and uses the first
+    string column as labels.
+
+    Args:
+        csv_data: Raw CSV text with a header row.
+        chart_type: Chart type or "auto".
+        x_column: Column to use for x-axis labels.
+        y_columns: Columns to use for y-axis data series.
+        title: Chart title.
+        theme: Theme preset or config dict.
+        output_format: Output format.
+        save_path: Optional save path.
+
+    Returns:
+        Chart content as string.
+
+    Raises:
+        ValueError: If CSV is empty or cannot be parsed.
+    """
+    if not csv_data or not csv_data.strip():
+        raise ValueError("CSV data is empty.")
+
+    reader = csv.DictReader(io.StringIO(csv_data.strip()))
+    fieldnames = reader.fieldnames
+    if not fieldnames or len(fieldnames) < 2:
+        raise ValueError(
+            "CSV must have a header row with at least two columns."
+        )
+
+    rows = list(reader)
+    if not rows:
+        raise ValueError("CSV has no data rows.")
+
+    # Determine which columns are numeric
+    numeric_cols = []
+    for col in fieldnames:
+        try:
+            [float(row[col]) for row in rows]
+            numeric_cols.append(col)
+        except (ValueError, TypeError):
+            pass
+
+    # Determine x_column (labels)
+    if x_column is None:
+        # First non-numeric column
+        non_numeric = [c for c in fieldnames if c not in numeric_cols]
+        if non_numeric:
+            x_column = non_numeric[0]
+        else:
+            x_column = None
+
+    # Determine y_columns
+    if y_columns is None:
+        y_columns = [c for c in numeric_cols if c != x_column]
+
+    if not y_columns:
+        raise ValueError("No numeric columns found for chart data.")
+
+    # Extract data
+    labels = [row[x_column] for row in rows] if x_column else None
+    data: list[float] | list[list[float]]
+    if len(y_columns) == 1:
+        data = [float(row[y_columns[0]]) for row in rows]
+    else:
+        data = [[float(row[col]) for row in rows] for col in y_columns]
+
+    series_names = y_columns if len(y_columns) > 1 else None
+
+    return handle_create_chart(
+        chart_type=chart_type,
+        data=data,
+        labels=labels,
+        title=title,
+        series_names=series_names,
+        theme=theme,
+        output_format=output_format,
+        save_path=save_path,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ docs = [
     "sphinx>=7.3.7",
     "furo>=2024.1.29",
 ]
+mcp = ["mcp>=1.0"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -74,6 +75,7 @@ indent-style = "space"
 
 [project.scripts]
 charted = "charted.__main__:main"
+charted-mcp = "mcp_server:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["charted", "duckdb_ext"]
+packages = ["charted", "duckdb_ext", "mcp_server"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,258 @@
+"""Tests for the MCP server tools.
+
+Tests the tool handler functions directly without MCP transport.
+"""
+
+import pytest
+
+from mcp_server.tools import (
+    handle_chart_from_csv,
+    handle_create_chart,
+    handle_list_chart_types,
+    handle_list_themes,
+)
+
+
+class TestCreateChart:
+    """Tests for the create_chart tool."""
+
+    def test_bar_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="bar",
+            data=[10, 20, 30],
+            labels=["A", "B", "C"],
+            title="Test Bar",
+        )
+        assert "<svg" in result
+        assert "</svg>" in result
+
+    def test_column_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="column",
+            data=[5, 15, 25, 35],
+            labels=["Q1", "Q2", "Q3", "Q4"],
+        )
+        assert "<svg" in result
+
+    def test_line_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="line",
+            data=[[1, 2, 3, 4], [4, 3, 2, 1]],
+            labels=["A", "B", "C", "D"],
+            series_names=["Up", "Down"],
+        )
+        assert "<svg" in result
+
+    def test_pie_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="pie",
+            data=[40, 30, 20, 10],
+            labels=["A", "B", "C", "D"],
+        )
+        assert "<svg" in result
+
+    def test_scatter_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="scatter",
+            data=[[1, 2, 3, 4, 5], [2, 4, 6, 8, 10]],
+        )
+        assert "<svg" in result
+
+    def test_area_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="area",
+            data=[10, 20, 15, 25, 30],
+            labels=["Mon", "Tue", "Wed", "Thu", "Fri"],
+        )
+        assert "<svg" in result
+
+    def test_radar_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="radar",
+            data=[80, 90, 70, 60, 85],
+            labels=["Speed", "Power", "Range", "Armor", "Magic"],
+        )
+        assert "<svg" in result
+
+    def test_histogram_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="histogram",
+            data=[1, 2, 2, 3, 3, 3, 4, 4, 5],
+        )
+        assert "<svg" in result
+
+    def test_heatmap_chart_svg(self):
+        result = handle_create_chart(
+            chart_type="heatmap",
+            data=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        )
+        assert "<svg" in result
+
+    def test_output_format_html(self):
+        result = handle_create_chart(
+            chart_type="bar",
+            data=[10, 20, 30],
+            labels=["A", "B", "C"],
+            output_format="html",
+        )
+        assert "<html" in result.lower() or "<div" in result.lower()
+        assert "<svg" in result
+
+    def test_output_format_data_url(self):
+        result = handle_create_chart(
+            chart_type="bar",
+            data=[10, 20, 30],
+            labels=["A", "B", "C"],
+            output_format="data_url",
+        )
+        assert result.startswith("data:image/svg+xml,")
+
+    def test_custom_dimensions(self):
+        result = handle_create_chart(
+            chart_type="bar",
+            data=[10, 20],
+            labels=["A", "B"],
+            width=800,
+            height=600,
+        )
+        assert "<svg" in result
+
+    def test_theme_string(self):
+        result = handle_create_chart(
+            chart_type="bar",
+            data=[10, 20, 30],
+            labels=["A", "B", "C"],
+            theme="dark",
+        )
+        assert "<svg" in result
+
+    def test_auto_chart_type(self):
+        result = handle_create_chart(
+            chart_type="auto",
+            data=[10, 20, 30, 40, 50, 60, 70],
+        )
+        assert "<svg" in result
+
+    def test_auto_chart_type_2d(self):
+        result = handle_create_chart(
+            chart_type="auto",
+            data=[[1, 2, 3, 4, 5, 6], [6, 5, 4, 3, 2, 1]],
+            labels=["A", "B", "C", "D", "E", "F"],
+            series_names=["Series 1", "Series 2"],
+        )
+        assert "<svg" in result
+
+    def test_save_path(self, tmp_path):
+        save_file = str(tmp_path / "test_chart.svg")
+        result = handle_create_chart(
+            chart_type="bar",
+            data=[10, 20, 30],
+            labels=["A", "B", "C"],
+            save_path=save_file,
+        )
+        assert "<svg" in result
+        with open(save_file) as f:
+            content = f.read()
+        assert "<svg" in content
+
+    def test_invalid_chart_type(self):
+        with pytest.raises((ValueError, KeyError)):
+            handle_create_chart(
+                chart_type="nonexistent",
+                data=[1, 2, 3],
+            )
+
+    def test_empty_data(self):
+        with pytest.raises((ValueError, TypeError)):
+            handle_create_chart(
+                chart_type="bar",
+                data=[],
+            )
+
+
+class TestListChartTypes:
+    """Tests for the list_chart_types tool."""
+
+    def test_returns_list(self):
+        result = handle_list_chart_types()
+        assert isinstance(result, list)
+
+    def test_contains_expected_types(self):
+        result = handle_list_chart_types()
+        type_names = [item["type"] for item in result]
+        expected = ["bar", "column", "line", "scatter", "pie", "radar", "area"]
+        for t in expected:
+            assert t in type_names
+
+    def test_each_entry_has_required_keys(self):
+        result = handle_list_chart_types()
+        for entry in result:
+            assert "type" in entry
+            assert "description" in entry
+
+
+class TestListThemes:
+    """Tests for the list_themes tool."""
+
+    def test_returns_dict(self):
+        result = handle_list_themes()
+        assert isinstance(result, dict)
+
+    def test_has_presets(self):
+        result = handle_list_themes()
+        assert "presets" in result
+        assert isinstance(result["presets"], list)
+        assert len(result["presets"]) > 0
+
+    def test_has_palettes(self):
+        result = handle_list_themes()
+        assert "palettes" in result
+        assert isinstance(result["palettes"], list)
+        assert "default" in result["palettes"]
+        assert "viridis" in result["palettes"]
+
+
+class TestChartFromCsv:
+    """Tests for the chart_from_csv tool."""
+
+    def test_simple_csv(self):
+        csv_data = "Name,Value\nAlpha,10\nBeta,20\nGamma,30"
+        result = handle_chart_from_csv(csv_data=csv_data, chart_type="bar")
+        assert "<svg" in result
+
+    def test_multi_series_csv(self):
+        csv_data = "Month,Revenue,Costs\nJan,120,80\nFeb,340,210\nMar,560,390"
+        result = handle_chart_from_csv(
+            csv_data=csv_data, chart_type="line", title="Financials"
+        )
+        assert "<svg" in result
+
+    def test_auto_type_csv(self):
+        csv_data = "Category,Value\nA,10\nB,20\nC,30\nD,40\nE,50"
+        result = handle_chart_from_csv(csv_data=csv_data)
+        assert "<svg" in result
+
+    def test_csv_with_output_format(self):
+        csv_data = "X,Y\n1,10\n2,20\n3,30"
+        result = handle_chart_from_csv(
+            csv_data=csv_data, chart_type="column", output_format="data_url"
+        )
+        assert result.startswith("data:image/svg+xml,")
+
+    def test_csv_x_column_specified(self):
+        csv_data = "Month,Revenue,Costs\nJan,120,80\nFeb,340,210\nMar,560,390"
+        result = handle_chart_from_csv(
+            csv_data=csv_data,
+            chart_type="bar",
+            x_column="Month",
+            y_columns=["Revenue"],
+        )
+        assert "<svg" in result
+
+    def test_empty_csv_raises(self):
+        with pytest.raises((ValueError, Exception)):
+            handle_chart_from_csv(csv_data="", chart_type="bar")
+
+    def test_invalid_csv_raises(self):
+        with pytest.raises((ValueError, Exception)):
+            handle_chart_from_csv(csv_data="no-header-single-word", chart_type="bar")


### PR DESCRIPTION
## Summary

- Implements #13: MCP server exposing charted's chart generation as tools for AI agents
- Four tools: `create_chart`, `list_chart_types`, `list_themes`, `chart_from_csv`
- Thin wrapper around charted's existing API using the `mcp` Python SDK (stdio transport)
- Added as optional dependency: `pip install charted[mcp]`
- Entry point: `charted-mcp` CLI or `python -m mcp_server`
- Full test suite with 31 tests covering all chart types, output formats, CSV parsing, and error handling

## Test plan

- [x] `pytest tests/test_mcp_server.py -x -q` passes (31 tests)
- [x] `ruff check .` passes
- [ ] Manual: `python -m mcp_server` starts without error
- [ ] Register with Claude Code: `claude mcp add charted -- python -m mcp_server`