### PR TITLE
Add DuckDB as optional dependency with package integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,11 @@ pip install 'charted[png]'
 # or just: pip install cairosvg
 ```
 
+For DuckDB integration (generate charts directly from SQL queries):
+```sh
+pip install 'charted[duckdb]'
+```
+
 For PNG visual testing (dev):
 ```sh
 pip install 'charted[dev]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     # Performance benchmarks
     "pytest-benchmark>=4.0.0",
 ]
+duckdb = ["duckdb>=0.9"]
 docs = [
     "sphinx>=7.3.7",
     "furo>=2024.1.29",
@@ -75,4 +76,4 @@ indent-style = "space"
 charted = "charted.__main__:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["charted"]
+packages = ["charted", "duckdb_ext"]


### PR DESCRIPTION
## Summary

- Adds `duckdb` as an optional dependency group: `pip install 'charted[duckdb]'`
- Includes `duckdb_ext` package in hatch wheel build targets
- Documents DuckDB integration in README installation section

The `duckdb_ext/` module (SQL-driven chart generation with Python API and SQL UDFs) was already present but not wired into pyproject.toml as a proper optional extra or build target.

## Test plan

- [x] `ruff check .` passes
- [x] `python -m pytest duckdb_ext/test_extension.py -x -q` — 9 tests pass
- [ ] Verify `pip install 'charted[duckdb]'` pulls duckdb