### PR TITLE
feat(cli): add --title/--width/--height and --transpose to create

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,11 @@ Chart type short names: `bar`, `column`, `line`, `scatter`, `pie`, `radar`, `are
 python -m charted create bar output.svg --data sales.csv
 python -m charted create column chart.svg -d data.json
 
+# Set title/dimensions (override a --config file); --transpose reads a
+# wide / series-per-row CSV instead of the default series-per-column layout
+python -m charted create bar out.svg -d sales.csv --title "Q3" --width 900
+python -m charted create column out.svg -d wide.csv --transpose
+
 # Batch: convert all files in a directory
 python -m charted batch input_dir/ output_dir/
 python -m charted batch input_dir/ output_dir/ --chart-type line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Charted will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `charted create` now accepts `--title`, `--width`, and `--height`. These set
+  the chart title and dimensions from the command line and override the matching
+  values in a `--config` file.
+- `charted create --transpose` reads a wide / series-per-row CSV, where each data
+  row is a series and the header row supplies the x-axis labels. The default
+  layout (first column as x labels, each other column as a series) is unchanged.
+
 ## [1.0.5] - 2026-05-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -436,16 +436,44 @@ python -m charted create bar output.svg --data sales.csv
 # From JSON
 python -m charted create column chart.svg -d data.json
 
+# Set the title and dimensions
+python -m charted create bar output.svg --data sales.csv \
+    --title "Q3 Sales" --width 900 --height 400
+
 # Batch from directory
 python -m charted batch input_data/ output_svg/
 ```
 
-**CSV format:**
+`--title`, `--width`, and `--height` override the same values in a `--config`
+file when you pass both.
+
+**CSV format (default):**
+
+The first column is the x-axis labels. Every other column is a data series.
+
 ```csv
 Quarter,Revenue,Expenses
 Q1,120,80
 Q2,180,95
 Q3,210,110
+```
+
+**Wide CSV (`--transpose`):**
+
+If your CSV is laid out sideways, with one series per row and the x values
+across the header, pass `--transpose`. The corner cell is ignored, the rest of
+the header row becomes the x-axis labels, and each following row is a series
+named by its first cell. Without `--transpose` this layout would plot with the
+axes swapped, so the flag is explicit rather than guessed.
+
+```csv
+Series,Q1,Q2,Q3
+Revenue,120,180,210
+Expenses,80,95,110
+```
+
+```sh
+python -m charted create column out.svg --data wide.csv --transpose
 ```
 
 **JSON format:**

--- a/charted/__main__.py
+++ b/charted/__main__.py
@@ -16,11 +16,47 @@ def main(args=None):
     # Create subcommand
     create_parser = subparsers.add_parser("create", help="Create a new chart")
     create_parser.add_argument(
-        "chart_type", choices=["bar", "column", "line", "pie", "radar", "scatter", "area", "boxplot", "histogram", "heatmap", "gantt", "combo"]
+        "chart_type",
+        choices=[
+            "bar",
+            "column",
+            "line",
+            "pie",
+            "radar",
+            "scatter",
+            "area",
+            "boxplot",
+            "histogram",
+            "heatmap",
+            "gantt",
+            "combo",
+        ],
     )
     create_parser.add_argument("output", help="Output SVG file path")
     create_parser.add_argument("--data", "-d", help="Data file (CSV or JSON)")
     create_parser.add_argument("--config", "-c", help="Config file path")
+    create_parser.add_argument(
+        "--title", help="Chart title (overrides a title in the config file)"
+    )
+    create_parser.add_argument(
+        "--width",
+        type=int,
+        help="Chart width in pixels (overrides the config file)",
+    )
+    create_parser.add_argument(
+        "--height",
+        type=int,
+        help="Chart height in pixels (overrides the config file)",
+    )
+    create_parser.add_argument(
+        "--transpose",
+        action="store_true",
+        help=(
+            "Read the CSV in wide layout: each data row is a series and the "
+            "header row supplies the x-axis labels. Default layout is the first "
+            "column as x labels with each other column as a series."
+        ),
+    )
     create_parser.set_defaults(func="create")
 
     # Batch subcommand
@@ -32,7 +68,20 @@ def main(args=None):
     batch_parser.add_argument(
         "--chart-type",
         "-t",
-        choices=["bar", "column", "line", "pie", "radar", "scatter", "area", "boxplot", "histogram", "heatmap", "gantt", "combo"],
+        choices=[
+            "bar",
+            "column",
+            "line",
+            "pie",
+            "radar",
+            "scatter",
+            "area",
+            "boxplot",
+            "histogram",
+            "heatmap",
+            "gantt",
+            "combo",
+        ],
         help="Override chart type inferred from filename",
     )
     batch_parser.add_argument("--config", "-c", help="Config file path")

--- a/charted/cli/create.py
+++ b/charted/cli/create.py
@@ -40,8 +40,17 @@ CHART_TYPES = {
 }
 
 
-def load_data(data_path: str) -> dict:
-    """Load data from CSV or JSON file."""
+def load_data(data_path: str, transpose: bool = False) -> dict:
+    """Load data from CSV or JSON file.
+
+    Args:
+        data_path: Path to a .csv or .json file.
+        transpose: Only applies to CSV. When False (default) the first column
+            holds the x-axis labels and every other column is a data series.
+            When True the layout is read sideways: each data row becomes a
+            series and the header row (minus the corner cell) supplies the
+            x-axis labels.
+    """
     path = Path(data_path)
 
     if not path.exists():
@@ -53,14 +62,33 @@ def load_data(data_path: str) -> dict:
         with open(path) as f:
             return json.load(f)
     elif suffix == ".csv":
-        return _parse_csv(path)
+        return _parse_csv(path, transpose=transpose)
     else:
         raise ValueError(f"Unsupported file format: {suffix}. Use .csv or .json")
 
 
-def _parse_csv(path: Path) -> dict:
-    """Parse CSV file into data dict."""
+def _to_number(value: str):
+    """Convert a CSV cell to a float, leaving non-numeric text untouched."""
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _parse_csv(path: Path, transpose: bool = False) -> dict:
+    """Parse a CSV file into a chart-compatible data dict.
+
+    Default layout (``transpose=False``): the first column is the x-axis
+    labels and each remaining column is a data series.
+
+    Wide layout (``transpose=True``): the first row is the header, where the
+    corner cell is ignored and the rest are the x-axis labels. Each subsequent
+    row is one series, named by its first cell.
+    """
     import csv
+
+    if transpose:
+        return _parse_csv_transposed(path)
 
     with open(path) as f:
         reader = csv.DictReader(f)
@@ -74,13 +102,8 @@ def _parse_csv(path: Path) -> dict:
     labels = [row[fieldnames[0]] for row in rows]
     data_values = []
 
-    for i, field in enumerate(fieldnames[1:], 1):
-        column_data = []
-        for row in rows:
-            try:
-                column_data.append(float(row[field]))
-            except ValueError:
-                column_data.append(row[field])
+    for field in fieldnames[1:]:
+        column_data = [_to_number(row[field]) for row in rows]
         data_values.append(column_data)
 
     # Return in chart-compatible format
@@ -88,6 +111,36 @@ def _parse_csv(path: Path) -> dict:
         return {"data": data_values[0], "labels": labels}
     else:
         return {"data": data_values, "labels": labels}
+
+
+def _parse_csv_transposed(path: Path) -> dict:
+    """Parse a wide / series-per-row CSV (see _parse_csv for the layout)."""
+    import csv
+
+    with open(path) as f:
+        rows = list(csv.reader(f))
+
+    # Drop blank trailing rows that csv.reader can leave behind.
+    rows = [row for row in rows if row]
+
+    if not rows:
+        return {"data": []}
+
+    header = rows[0]
+    labels = header[1:]
+    series_names = []
+    data_values = []
+
+    for row in rows[1:]:
+        series_names.append(row[0])
+        data_values.append([_to_number(cell) for cell in row[1:]])
+
+    result: dict = {"labels": labels, "series_names": series_names}
+    if len(data_values) == 1:
+        result["data"] = data_values[0]
+    else:
+        result["data"] = data_values
+    return result
 
 
 def _build_combo_kwargs(data: dict) -> dict:
@@ -158,7 +211,7 @@ def create_command(args: argparse.Namespace):
     data = {}
     if args.data:
         try:
-            data = load_data(args.data)
+            data = load_data(args.data, transpose=getattr(args, "transpose", False))
         except (FileNotFoundError, ValueError) as e:
             error_msg = str(e)
             if "not found" in error_msg:
@@ -192,6 +245,40 @@ def create_command(args: argparse.Namespace):
                 file=sys.stderr,
             )
             sys.exit(1)
+
+    # Merge in a config file, then let explicit CLI flags win over it. Config
+    # values seed the chart kwargs; --title / --width / --height override the
+    # matching config entry when supplied (and override loaded data too).
+    if getattr(args, "config", None):
+        try:
+            with open(args.config) as f:
+                config = json.load(f)
+        except FileNotFoundError:
+            print(f"Error: Config file not found: {args.config}", file=sys.stderr)
+            print(
+                "  Suggestion: Check the file path and ensure it exists",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error reading config file: {e}", file=sys.stderr)
+            print(
+                "  Suggestion: Check that the config file is valid JSON",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        # config file is the base layer, data file overrides it.
+        merged = dict(config)
+        merged.update(data)
+        data = merged
+
+    # CLI flags take precedence over both the config file and the data file.
+    if getattr(args, "title", None) is not None:
+        data["title"] = args.title
+    if getattr(args, "width", None) is not None:
+        data["width"] = args.width
+    if getattr(args, "height", None) is not None:
+        data["height"] = args.height
 
     # Create chart
     try:

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -10,6 +10,28 @@ import pytest
 from charted.cli.create import _parse_csv, create_command, load_data
 
 
+def _ns(**kwargs):
+    """Build an argparse.Namespace with CLI defaults filled in.
+
+    Tests only need to set the fields they care about; everything else
+    falls back to the same defaults argparse would supply.
+    """
+    import argparse
+
+    defaults = {
+        "chart_type": "bar",
+        "output": None,
+        "data": None,
+        "config": None,
+        "title": None,
+        "width": None,
+        "height": None,
+        "transpose": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
 class TestLoadData:
     """Test load_data function for CSV and JSON files."""
 
@@ -459,3 +481,141 @@ class TestCLIIntegration:
                 create_command(args)
 
                 assert output_file.exists()
+
+
+class TestTitleAndDimensions:
+    """Test --title, --width, --height CLI options."""
+
+    def test_title_sets_chart_title(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "out.svg"
+            data_file = Path(tmpdir) / "data.json"
+            data_file.write_text(json.dumps({"labels": ["A", "B"], "data": [10, 20]}))
+
+            create_command(
+                _ns(output=str(output_file), data=str(data_file), title="My Report")
+            )
+
+            content = output_file.read_text()
+            assert "My Report" in content
+
+    def test_width_and_height_change_dimensions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "out.svg"
+            data_file = Path(tmpdir) / "data.json"
+            data_file.write_text(json.dumps({"labels": ["A", "B"], "data": [10, 20]}))
+
+            create_command(
+                _ns(
+                    output=str(output_file),
+                    data=str(data_file),
+                    width=900,
+                    height=400,
+                )
+            )
+
+            content = output_file.read_text()
+            assert 'width="900"' in content
+            assert 'height="400"' in content
+            assert 'viewBox="0 0 900 400"' in content
+
+    def test_cli_title_overrides_config(self):
+        """A --title flag takes precedence over a title in the config file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "out.svg"
+            data_file = Path(tmpdir) / "data.json"
+            data_file.write_text(json.dumps({"labels": ["A", "B"], "data": [10, 20]}))
+            config_file = Path(tmpdir) / "cfg.json"
+            config_file.write_text(json.dumps({"title": "From Config", "width": 600}))
+
+            create_command(
+                _ns(
+                    output=str(output_file),
+                    data=str(data_file),
+                    config=str(config_file),
+                    title="From CLI",
+                )
+            )
+
+            content = output_file.read_text()
+            assert "From CLI" in content
+            assert "From Config" not in content
+
+    def test_config_title_used_when_no_cli_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "out.svg"
+            data_file = Path(tmpdir) / "data.json"
+            data_file.write_text(json.dumps({"labels": ["A", "B"], "data": [10, 20]}))
+            config_file = Path(tmpdir) / "cfg.json"
+            config_file.write_text(json.dumps({"title": "From Config"}))
+
+            create_command(
+                _ns(
+                    output=str(output_file),
+                    data=str(data_file),
+                    config=str(config_file),
+                )
+            )
+
+            assert "From Config" in output_file.read_text()
+
+
+class TestCSVOrientation:
+    """Test CSV orientation handling and the --transpose flag."""
+
+    def test_default_orientation_series_per_column(self):
+        """Default: first column is x labels, each other column is a series."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = Path(tmpdir) / "data.csv"
+            data_file.write_text("Quarter,Revenue\nQ1,120\nQ2,180\nQ3,210")
+
+            result = load_data(str(data_file))
+            assert result["labels"] == ["Q1", "Q2", "Q3"]
+            assert result["data"] == [120.0, 180.0, 210.0]
+
+    def test_transpose_series_per_row(self):
+        """With transpose=True, each data row is a series and the header row
+        (minus the corner cell) supplies the x labels."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = Path(tmpdir) / "data.csv"
+            # Wide layout: series live on rows, x values across the header.
+            data_file.write_text(
+                "Series,Q1,Q2,Q3\nRevenue,120,180,210\nExpenses,80,95,110"
+            )
+
+            result = load_data(str(data_file), transpose=True)
+            assert result["labels"] == ["Q1", "Q2", "Q3"]
+            assert result["data"] == [[120.0, 180.0, 210.0], [80.0, 95.0, 110.0]]
+            assert result["series_names"] == ["Revenue", "Expenses"]
+
+    def test_transpose_single_series_per_row(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = Path(tmpdir) / "data.csv"
+            data_file.write_text("Series,Q1,Q2,Q3\nRevenue,120,180,210")
+
+            result = load_data(str(data_file), transpose=True)
+            assert result["labels"] == ["Q1", "Q2", "Q3"]
+            assert result["data"] == [120.0, 180.0, 210.0]
+            assert result["series_names"] == ["Revenue"]
+
+    def test_transpose_via_create_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "out.svg"
+            data_file = Path(tmpdir) / "data.csv"
+            data_file.write_text(
+                "Series,Q1,Q2,Q3\nRevenue,120,180,210\nExpenses,80,95,110"
+            )
+
+            create_command(
+                _ns(
+                    chart_type="column",
+                    output=str(output_file),
+                    data=str(data_file),
+                    transpose=True,
+                )
+            )
+
+            content = output_file.read_text()
+            assert "Q1" in content
+            assert "Q2" in content
+            assert "<svg" in content


### PR DESCRIPTION
## What

Two gaps in `charted create` that surfaced while plotting a benchmark from the command line.

### 1. No way to set title or dimensions from the CLI

`charted create <type> <out> --data <file>` only took `--data` and `--config`. There was no way to set a title or size without writing Python or a config file.

Added `--title`, `--width`, and `--height`. They wire straight into the chart constructor, so `--title "Foo"` renders "Foo" as the chart title and `--width 900` changes the output width and viewBox. When a `--config` file also sets these, the CLI flag wins (config seeds the kwargs, the flag overrides it).

### 2. Wide CSVs were silently transposed

The CLI CSV reader (`_parse_csv`) treats the first column as the x-axis labels and every other column as a data series. A wide / series-per-row CSV, the layout where each row is a series and the x values run across the header, got plotted with the axes swapped and no warning. That is what bit the benchmark plot.

Added a `--transpose` flag for the wide layout: the corner cell is ignored, the rest of the header row becomes the x labels, and each following row is a series named by its first cell. The default (series-per-column) layout is unchanged, so this is backward compatible.

**Decision: explicit flag, not auto-detect.** Auto-detection has no reliable signal here. Numeric headers, all-numeric data, and a numeric label column all look the same to a heuristic, so guessing would just trade one silent-wrong-output failure for another. An explicit flag is predictable and documented. This matches the task's stated preference for a clear flag over fragile guessing.

## Tests

TDD: wrote the failing tests first, then implemented.

- `--title` sets the title, `--width`/`--height` change dimensions and viewBox
- CLI flag overrides a config-file value; config value is used when no flag is passed
- default CSV orientation still parses series-per-column
- `--transpose` parses single and multi series, and renders end to end via `create_command`

Full local run (CI-equivalent, ignoring the font + visual-baseline suites CI also ignores): 1129 passed, 1 skipped, 0 failures. `ruff check .` clean, `ruff format` applied.

The `tests/charts/test_visual.py` PNG/SVG baselines fail on my machine due to a local font-rendering difference. They are pre-existing (they fail on a clean `main` too) and CI ignores that suite, so they are not affected by this change.

## Docs

Updated the README CSV section (default vs `--transpose` layouts), the `create` help text, CHANGELOG, and AGENTS.md.
