### PR TITLE
docs: JetBrains Mono for code + em-dash sweep on the docs site

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,4 +1,16 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
+
 /* Charted Custom Styles */
+
+/* Use JetBrains Mono for all code / monospace text. Furo reads this variable
+   for inline code, code blocks, and kbd. */
+:root,
+body,
+body[data-theme="dark"],
+body[data-theme="light"] {
+    --font-stack--monospace: "JetBrains Mono", ui-monospace, SFMono-Regular,
+        "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
 
 /* Hero section styling */
 .hero-section {

--- a/docs/api/charts.rst
+++ b/docs/api/charts.rst
@@ -25,11 +25,11 @@ Column Chart
 
    **Key Parameters:**
 
-   - ``data`` — List of lists for multi-series, or single list for one series
-   - ``labels`` — X-axis labels
-   - ``series_names`` — Names for each data series (used in legend)
-   - ``y_stacked`` — If True, stack bars vertically (default for multi-series)
-   - ``theme`` — Theme dictionary or theme name string
+   - ``data``: List of lists for multi-series, or single list for one series
+   - ``labels``: X-axis labels
+   - ``series_names``: Names for each data series (used in legend)
+   - ``y_stacked``: If True, stack bars vertically (default for multi-series)
+   - ``theme``: Theme dictionary or theme name string
 
    **Example:**
 
@@ -57,10 +57,10 @@ Bar Chart
 
    **Key Parameters:**
 
-   - ``data`` — Single list or list of lists for multi-series
-   - ``labels`` — Y-axis labels
-   - ``x_stacked`` — If True, stack bars horizontally
-   - ``theme`` — Theme dictionary or theme name string
+   - ``data``: Single list or list of lists for multi-series
+   - ``labels``: Y-axis labels
+   - ``x_stacked``: If True, stack bars horizontally
+   - ``theme``: Theme dictionary or theme name string
 
    **Example:**
 
@@ -87,10 +87,10 @@ Line Chart
 
    **Key Parameters:**
 
-   - ``data`` — List of lists for multi-series
-   - ``labels`` — X-axis labels (or ``x_data`` for XY mode)
-   - ``x_data`` — Custom X-axis values for XY mode
-   - ``theme`` — Theme dictionary or theme name string
+   - ``data``: List of lists for multi-series
+   - ``labels``: X-axis labels (or ``x_data`` for XY mode)
+   - ``x_data``: Custom X-axis values for XY mode
+   - ``theme``: Theme dictionary or theme name string
 
    **Example:**
 
@@ -118,10 +118,10 @@ Scatter Chart
 
    **Key Parameters:**
 
-   - ``data`` — List of [x, y] pairs or list of lists for multi-series
-   - ``labels`` — Series names
-   - ``marker_shape`` — "circle", "square", or "diamond"
-   - ``theme`` — Theme dictionary or theme name string
+   - ``data``: List of [x, y] pairs or list of lists for multi-series
+   - ``labels``: Series names
+   - ``marker_shape``: "circle", "square", or "diamond"
+   - ``theme``: Theme dictionary or theme name string
 
    **Example:**
 
@@ -149,11 +149,11 @@ Pie Chart
 
    **Key Parameters:**
 
-   - ``data`` — Single list of values
-   - ``labels`` — Slice labels
-   - ``series_names`` — Legend name
-    - ``inner_radius`` — Inner radius for doughnut mode (0.3-0.7, 0 = regular pie)
-    - ``slice_styles`` — Per-slice customization (colors, explosion, labels)
+   - ``data``: Single list of values
+   - ``labels``: Slice labels
+   - ``series_names``: Legend name
+    - ``inner_radius``: Inner radius for doughnut mode (0.3-0.7, 0 = regular pie)
+    - ``slice_styles``: Per-slice customization (colors, explosion, labels)
 
    **Example:**
 
@@ -205,10 +205,10 @@ Radar Chart
 
    **Key Parameters:**
 
-   - ``data`` — List of lists for multi-series, each inner list has one value per axis
-   - ``labels`` — Axis labels (one per data point)
-   - ``series_names`` — Names for each data series (used in legend)
-   - ``theme`` — Theme dictionary or theme name string
+   - ``data``: List of lists for multi-series, each inner list has one value per axis
+   - ``labels``: Axis labels (one per data point)
+   - ``series_names``: Names for each data series (used in legend)
+   - ``theme``: Theme dictionary or theme name string
 
    **Example:**
 
@@ -246,7 +246,7 @@ All chart types share these methods:
 
 .. py:method:: _repr_html_()
 
-   IPython/Jupyter integration — returns HTML with inline SVG.
+   IPython/Jupyter integration: returns HTML with inline SVG.
 
 Data Loading API
 ----------------
@@ -257,10 +257,10 @@ Data Loading API
 
    **Parameters:**
 
-   - ``filepath`` — Path to CSV file
-   - ``x_col`` — Column name for X-axis/labels
-   - ``y_cols`` — Column name(s) for Y-axis data
-   - ``delimiter`` — CSV delimiter (default: ",")
+   - ``filepath``: Path to CSV file
+   - ``x_col``: Column name for X-axis/labels
+   - ``y_cols``: Column name(s) for Y-axis data
+   - ``delimiter``: CSV delimiter (default: ",")
 
    **Returns:** Tuple of (x_values, y_values, column_names)
 
@@ -270,7 +270,7 @@ Data Loading API
 
    **Parameters:**
 
-   - ``filepath`` — Path to JSON file
+   - ``filepath``: Path to JSON file
 
    **Returns:** Tuple of (x_values, y_values, column_names)
 
@@ -309,7 +309,7 @@ Theme API
 
    **Parameters:**
 
-   - ``theme_name`` — Theme name string or theme dictionary
+   - ``theme_name``: Theme name string or theme dictionary
 
    **Returns:** Theme dictionary with chart styling
 

--- a/docs/api/themes.rst
+++ b/docs/api/themes.rst
@@ -8,9 +8,9 @@ Built-in Themes
 
 The following presets are available out of the box:
 
-- ``"dark"`` — Dark background with high-contrast light colors
-- ``"light"`` — Light background with subtle grid lines
-- ``"high-contrast"`` — Maximum visibility with bold colors
+- ``"dark"``: Dark background with high-contrast light colors
+- ``"light"``: Light background with subtle grid lines
+- ``"high-contrast"``: Maximum visibility with bold colors
 
 Using the ``theme.load()`` method to load a theme by name:
 

--- a/docs/charts/area.rst
+++ b/docs/charts/area.rst
@@ -91,15 +91,15 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Single list (one series) or list of lists (multi-series)
-   - ``labels`` — X-axis categories
-   - ``x_data`` — Optional x-axis values for XY mode
-   - ``series_names`` — Series names for legend
-   - ``width`` — Width in pixels (default 800)
-   - ``height`` — Height in pixels (default 600)
-   - ``fill_opacity`` — Fill opacity 0-1 (default 0.1)
-   - ``theme`` — Theme string or dict
-   - ``title`` — Chart title
+   - ``data``: Single list (one series) or list of lists (multi-series)
+   - ``labels``: X-axis categories
+   - ``x_data``: Optional x-axis values for XY mode
+   - ``series_names``: Series names for legend
+   - ``width``: Width in pixels (default 800)
+   - ``height``: Height in pixels (default 600)
+   - ``fill_opacity``: Fill opacity 0-1 (default 0.1)
+   - ``theme``: Theme string or dict
+   - ``title``: Chart title
 
    **Example:**
 

--- a/docs/charts/bar.rst
+++ b/docs/charts/bar.rst
@@ -114,16 +114,16 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Single list for one series, or list of lists for multi-series
-   - ``labels`` — Y-axis category labels
-   - ``series_names`` — Names for each data series (shown in legend)
-   - ``x_stacked`` — If True, stack bars horizontally
-   - ``bar_gap`` — Gap between bars as ratio (0-1, default 0.5)
-   - ``width`` — Chart width in pixels (default 800)
-   - ``height`` — Chart height in pixels (default 600)
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``subtitle`` — Optional subtitle text
+   - ``data``: Single list for one series, or list of lists for multi-series
+   - ``labels``: Y-axis category labels
+   - ``series_names``: Names for each data series (shown in legend)
+   - ``x_stacked``: If True, stack bars horizontally
+   - ``bar_gap``: Gap between bars as ratio (0-1, default 0.5)
+   - ``width``: Chart width in pixels (default 800)
+   - ``height``: Chart height in pixels (default 600)
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``subtitle``: Optional subtitle text
 
    **Example:**
 

--- a/docs/charts/boxplot.rst
+++ b/docs/charts/boxplot.rst
@@ -50,12 +50,12 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — List of lists; each inner list is raw data values for one group
-   - ``labels`` — Labels for each group (box)
-   - ``width`` — Chart width in pixel (default 800)
-   - ``height`` — Chart height pixels (default 600)
-   - ``theme`` — Theme string dict
-   - ``title`` — Chart title
+   - ``data``: List of lists; each inner list is raw data values for one group
+   - ``labels``: Labels for each group (box)
+   - ``width``: Chart width in pixel (default 800)
+   - ``height``: Chart height pixels (default 600)
+   - ``theme``: Theme string dict
+   - ``title``: Chart title
 
    **Example:**
 

--- a/docs/charts/bubble.rst
+++ b/docs/charts/bubble.rst
@@ -58,16 +58,16 @@ API Reference
 
    **Parameters:**
 
-   - ``x_data`` — X coordinates for each point
-   - ``y_data`` — Y coordinates for each point
-   - ``sizes`` — Third dimension; one non-negative value per point
-   - ``min_radius`` — Smallest rendered marker radius in pixels (default 4.0)
-   - ``max_radius`` — Largest rendered marker radius in pixels (default 24.0)
-   - ``width`` — Chart width in pixels
-   - ``height`` — Chart height in pixels
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``series_names`` — Names for each series (shown in legend)
+   - ``x_data``: X coordinates for each point
+   - ``y_data``: Y coordinates for each point
+   - ``sizes``: Third dimension; one non-negative value per point
+   - ``min_radius``: Smallest rendered marker radius in pixels (default 4.0)
+   - ``max_radius``: Largest rendered marker radius in pixels (default 24.0)
+   - ``width``: Chart width in pixels
+   - ``height``: Chart height in pixels
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``series_names``: Names for each series (shown in legend)
 
    **Example:**
 

--- a/docs/charts/column.rst
+++ b/docs/charts/column.rst
@@ -116,16 +116,16 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Single list for one series, or list of lists for multi-series
-   - ``labels`` — X-axis category labels
-   - ``series_names`` — Names for each data series (shown in legend)
-   - ``y_stacked`` — If True, stack columns vertically (default for multi-series)
-   - ``column_gap`` — Gap between columns as ratio (0-1, default 0.5)
-   - ``width`` — Chart width in pixels (default 800)
-   - ``height`` — Chart height in pixels (default 600)
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``subtitle`` — Optional subtitle text
+   - ``data``: Single list for one series, or list of lists for multi-series
+   - ``labels``: X-axis category labels
+   - ``series_names``: Names for each data series (shown in legend)
+   - ``y_stacked``: If True, stack columns vertically (default for multi-series)
+   - ``column_gap``: Gap between columns as ratio (0-1, default 0.5)
+   - ``width``: Chart width in pixels (default 800)
+   - ``height``: Chart height in pixels (default 600)
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``subtitle``: Optional subtitle text
 
    **Example:**
 

--- a/docs/charts/combo.rst
+++ b/docs/charts/combo.rst
@@ -55,14 +55,14 @@ API Reference
 
    **Parameters:**
 
-   - ``series`` — List of series dicts, each with ``data``, ``type``, optional ``name`` and optional ``axis``
-   - ``labels`` — Category labels for the shared x-axis
-   - ``width`` — Chart width in pixels (default 800)
-   - ``height`` — Chart height in pixels (default 600)
-   - ``title`` — Chart title text
-   - ``theme`` — Theme name string or theme dictionary
-   - ``x_label``, ``y_label`` — Optional axis titles
-   - ``column_gap`` — Gap between side-by-side columns (default 0.2)
+   - ``series``: List of series dicts, each with ``data``, ``type``, optional ``name`` and optional ``axis``
+   - ``labels``: Category labels for the shared x-axis
+   - ``width``: Chart width in pixels (default 800)
+   - ``height``: Chart height in pixels (default 600)
+   - ``title``: Chart title text
+   - ``theme``: Theme name string or theme dictionary
+   - ``x_label``, ``y_label``: Optional axis titles
+   - ``column_gap``: Gap between side-by-side columns (default 0.2)
 
    **Example:**
 

--- a/docs/charts/gantt.rst
+++ b/docs/charts/gantt.rst
@@ -70,16 +70,16 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — List of (start, end) tuples for task bars
-   - ``labels`` — Task names on the y-axis
-   - ``width`` — Chart px px (default 800)
-   - ``height`` — Chart pixel px (default 600)
-   - ``dependencies`` — List of (from, to) task index tuples for arrows
-   - ``bar_height_ratio`` — Bar height as fraction of row (default 0.6)
-   - ``show_today_line`` — Draw dashed vertical line at x_position
-   - ``x_position`` — X value for the "today" line
-   - ``theme`` — Theme dictionary or string
-   - ``title`` — Chart title
+   - ``data``: List of (start, end) tuples for task bars
+   - ``labels``: Task names on the y-axis
+   - ``width``: Chart px px (default 800)
+   - ``height``: Chart pixel px (default 600)
+   - ``dependencies``: List of (from, to) task index tuples for arrows
+   - ``bar_height_ratio``: Bar height as fraction of row (default 0.6)
+   - ``show_today_line``: Draw dashed vertical line at x_position
+   - ``x_position``: X value for the "today" line
+   - ``theme``: Theme dictionary or string
+   - ``title``: Chart title
 
    **Example:**
 

--- a/docs/charts/heatmap.rst
+++ b/docs/charts/heatmap.rst
@@ -113,20 +113,20 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — 2D matrix (list of list of numbers)
-   - ``x_labels`` — Column labels (auto-generated if omitted)
-   - ``y_labels`` — Row labels (auto-generated if omitted)
-   - ``width`` — Chart px (default 800)
-   - ``height`` — Chart px (default 600)
-   - ``low_color`` — Color for minimum value (default "#1a6b8f")
-   - ``high_color`` — Color for maximum value (default "#f7a55c")
-   - ``color_scale`` — Continuous multi-stop gradient: a named palette (e.g. "viridis"), a list of hex stops, or a ``ColorScale``. Overrides ``low_color``/``high_color`` (default None)
-   - ``show_values`` — Display values in cells (default True)
-   - ``value_format`` — Format string for cell values (default ".1f")
-   - ``cell_gap`` — Gap between cells as fraction (default 0.04)
-   - ``label_font_size`` — Label font size px (default 11)
-   - ``theme`` — Theme or theme dict
-   - ``title`` — Chart title
+   - ``data``: 2D matrix (list of list of numbers)
+   - ``x_labels``: Column labels (auto-generated if omitted)
+   - ``y_labels``: Row labels (auto-generated if omitted)
+   - ``width``: Chart px (default 800)
+   - ``height``: Chart px (default 600)
+   - ``low_color``: Color for minimum value (default "#1a6b8f")
+   - ``high_color``: Color for maximum value (default "#f7a55c")
+   - ``color_scale``: Continuous multi-stop gradient: a named palette (e.g. "viridis"), a list of hex stops, or a ``ColorScale``. Overrides ``low_color``/``high_color`` (default None)
+   - ``show_values``: Display values in cells (default True)
+   - ``value_format``: Format string for cell values (default ".1f")
+   - ``cell_gap``: Gap between cells as fraction (default 0.04)
+   - ``label_font_size``: Label font size px (default 11)
+   - ``theme``: Theme or theme dict
+   - ``title``: Chart title
 
    **Example:**
 

--- a/docs/charts/histogram.rst
+++ b/docs/charts/histogram.rst
@@ -68,13 +68,13 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Single flat list of numeric values to bin
-   - ``bins`` — Number of bins (auto-computed if None)
-   - ``labels`` — Optional x-axis labels (auto-generated if omitted)
-   - ``width`` — Chart width px (default 800)
-   - ``height`` — Chart height px (default 600)
-   - ``theme`` — Theme dict or string
-   - ``title`` — Chart title
+   - ``data``: Single flat list of numeric values to bin
+   - ``bins``: Number of bins (auto-computed if None)
+   - ``labels``: Optional x-axis labels (auto-generated if omitted)
+   - ``width``: Chart width px (default 800)
+   - ``height``: Chart height px (default 600)
+   - ``theme``: Theme dict or string
+   - ``title``: Chart title
 
    **Example:**
 

--- a/docs/charts/line.rst
+++ b/docs/charts/line.rst
@@ -197,15 +197,15 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Single list for one series, or list of lists for multi-series
-   - ``labels`` — X-axis labels (or use ``x_data`` for XY mode)
-   - ``x_data`` — Custom x-axis values for XY mode (optional)
-   - ``series_names`` — Names for each data series (shown in legend)
-   - ``width`` — Chart width in pixels (default 800)
-   - ``height`` — Chart height in pixels (default 600)
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``subtitle`` — Optional subtitle text
+   - ``data``: Single list for one series, or list of lists for multi-series
+   - ``labels``: X-axis labels (or use ``x_data`` for XY mode)
+   - ``x_data``: Custom x-axis values for XY mode (optional)
+   - ``series_names``: Names for each data series (shown in legend)
+   - ``width``: Chart width in pixels (default 800)
+   - ``height``: Chart height in pixels (default 600)
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``subtitle``: Optional subtitle text
 
    **Example:**
 

--- a/docs/charts/pie.rst
+++ b/docs/charts/pie.rst
@@ -189,20 +189,20 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Single list of values (one slice per value)
-   - ``labels`` — Slice labels
-   - ``inner_radius`` — Inner radius ratio for doughnut mode (0.3-0.7, default: 0; 0 = regular pie)
-   - ``slice_styles`` — Dictionary mapping slice index to style overrides
-   - ``height`` — Chart height in pixels (default 600)
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``subtitle`` — Optional subtitle text
+   - ``data``: Single list of values (one slice per value)
+   - ``labels``: Slice labels
+   - ``inner_radius``: Inner radius ratio for doughnut mode (0.3-0.7, default: 0; 0 = regular pie)
+   - ``slice_styles``: Dictionary mapping slice index to style overrides
+   - ``height``: Chart height in pixels (default 600)
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``subtitle``: Optional subtitle text
 
    **Slice Style Options:**
 
-   - ``color`` — Override slice color
-   - ``explode`` — Explode distance (0-1 ratio)
-   - ``label_position`` — "inside", "outside", or "auto"
+   - ``color``: Override slice color
+   - ``explode``: Explode distance (0-1 ratio)
+   - ``label_position``: "inside", "outside", or "auto"
 
    **Example:**
 

--- a/docs/charts/polar_area.rst
+++ b/docs/charts/polar_area.rst
@@ -56,15 +56,15 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Non-negative values, one per slice
-   - ``labels`` — Labels for each slice
-   - ``width`` — Chart width in pixels
-   - ``height`` — Chart height in pixels
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``start_angle`` — Starting angle in degrees (0 = top, clockwise)
-   - ``series_styles`` — Optional per-slice styling overrides
-   - ``show_percentages`` — Show each slice's percentage of the total
+   - ``data``: Non-negative values, one per slice
+   - ``labels``: Labels for each slice
+   - ``width``: Chart width in pixels
+   - ``height``: Chart height in pixels
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``start_angle``: Starting angle in degrees (0 = top, clockwise)
+   - ``series_styles``: Optional per-slice styling overrides
+   - ``show_percentages``: Show each slice's percentage of the total
 
    **Example:**
 

--- a/docs/charts/radar.rst
+++ b/docs/charts/radar.rst
@@ -125,18 +125,18 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — Single list of values or list of lists for multi-series
-   - ``labels`` — Labels for each axis (one per data point in series)
-   - ``series_names`` — Names for each data series (shown in legend)
-   - ``radius`` — Chart radius as ratio of min(width, height) (default 0.45)
-   - ``grid_levels`` — Number of concentric grid circles (default 5)
-   - ``show_axis_labels`` — Whether to display axis labels (default True)
-   - ``label_offset`` — Distance from grid edge for labels (default 20)
-   - ``width`` — Chart width in pixels (default 500)
-   - ``height`` — Chart height in pixels (default 500)
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``subtitle`` — Optional subtitle text
+   - ``data``: Single list of values or list of lists for multi-series
+   - ``labels``: Labels for each axis (one per data point in series)
+   - ``series_names``: Names for each data series (shown in legend)
+   - ``radius``: Chart radius as ratio of min(width, height) (default 0.45)
+   - ``grid_levels``: Number of concentric grid circles (default 5)
+   - ``show_axis_labels``: Whether to display axis labels (default True)
+   - ``label_offset``: Distance from grid edge for labels (default 20)
+   - ``width``: Chart width in pixels (default 500)
+   - ``height``: Chart height in pixels (default 500)
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``subtitle``: Optional subtitle text
 
    **Example:**
 

--- a/docs/charts/scatter.rst
+++ b/docs/charts/scatter.rst
@@ -205,15 +205,15 @@ API Reference
 
    **Parameters:**
 
-   - ``data`` — List of [x, y] pairs, or list of lists for multi-series
-   - ``x_data`` — Alternative: explicit x values (optional)
-   - ``y_data`` — Alternative: explicit y values (optional)
-   - ``labels`` — Series names (shown in legend)
-   - ``width`` — Chart width in pixels (default 800)
-   - ``height`` — Chart height in pixels (default 600)
-   - ``theme`` — Theme name string or theme dictionary
-   - ``title`` — Chart title text
-   - ``subtitle`` — Optional subtitle text
+   - ``data``: List of [x, y] pairs, or list of lists for multi-series
+   - ``x_data``: Alternative: explicit x values (optional)
+   - ``y_data``: Alternative: explicit y values (optional)
+   - ``labels``: Series names (shown in legend)
+   - ``width``: Chart width in pixels (default 800)
+   - ``height``: Chart height in pixels (default 600)
+   - ``theme``: Theme name string or theme dictionary
+   - ``title``: Chart title text
+   - ``subtitle``: Optional subtitle text
 
    **Example:**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 ================================================================================
-**Charted** — Zero-Dependency SVG Charting for Python
+**Charted**: Zero-Dependency SVG Charting for Python
 ================================================================================
 
 .. raw:: html
@@ -121,7 +121,7 @@ Quick Start
 
          from charted import BarChart
 
-         # Just create a chart — it renders inline
+         # Just create a chart: it renders inline
          BarChart(
              data=[120, 180, 210, 150],
              labels=["Q1", "Q2", "Q3", "Q4"],
@@ -415,7 +415,7 @@ Documentation
 License
 ================================================================================
 
-MIT License — See `LICENSE <https://github.com/marzukia/charted/blob/main/LICENSE>`_ for details.
+MIT License: See `LICENSE <https://github.com/marzukia/charted/blob/main/LICENSE>`_ for details.
 
 ================================================================================
 Community


### PR DESCRIPTION
Fixes the docs site font and finishes the AI-tell cleanup on the documentation.

## Font
- Loads the JetBrains Mono web font and points Furo's `--font-stack--monospace` variable at it, so inline code and code blocks on charted.mrzk.io render in JetBrains Mono instead of the system monospace fallback.

## Em-dash sweep
- Strips em dashes out of the reStructuredText docs (the landing title and prose across the API/chart pages), replacing them with colons, matching the cleanup already done in the shipped package and README in 1.1.0.

Verified: `sphinx-build` succeeds (no new errors), and the built custom.css contains the JetBrains Mono font and import.

Deploys to charted.mrzk.io via the docs workflow on merge to main.