### PR TITLE
types: adopt mypy --strict across the charted package

### DIFF
--- a/charted/__main__.py
+++ b/charted/__main__.py
@@ -2,9 +2,10 @@
 
 import argparse
 import sys
+from collections.abc import Sequence
 
 
-def main(args=None):
+def main(args: Sequence[str] | None = None) -> None:
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
         prog="charted",
@@ -87,21 +88,21 @@ def main(args=None):
     batch_parser.add_argument("--config", "-c", help="Config file path")
     batch_parser.set_defaults(func="batch")
 
-    args = parser.parse_args(args)
+    parsed_args = parser.parse_args(args)
 
-    if args.command is None:
+    if parsed_args.command is None:
         parser.print_help()
         sys.exit(1)
 
     # Import here to avoid circular imports
-    if args.command == "create":
+    if parsed_args.command == "create":
         from .cli.create import create_command
 
-        create_command(args)
-    elif args.command == "batch":
+        create_command(parsed_args)
+    elif parsed_args.command == "batch":
         from .cli.batch import batch_command
 
-        batch_command(args)
+        batch_command(parsed_args)
 
 
 if __name__ == "__main__":

--- a/charted/chart_config.py
+++ b/charted/chart_config.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
+from typing import Any
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -72,7 +73,7 @@ class ChartConfig:
     x_scale: object | None = None
     y_scale: object | None = None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert config to dictionary for serialization.
 
         Returns:
@@ -86,7 +87,7 @@ class ChartConfig:
         return dataclasses.asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict) -> Self:
+    def from_dict(cls, data: dict[str, Any]) -> Self:
         """Create config from dictionary.
 
         Args:
@@ -101,7 +102,7 @@ class ChartConfig:
         valid_fields = {f.name for f in dataclasses.fields(cls)}
         return cls(**{k: v for k, v in data.items() if k in valid_fields})
 
-    def update(self, **kwargs) -> Self:
+    def update(self, **kwargs: Any) -> Self:
         """Update config with new values and return self.
 
         Args:
@@ -212,7 +213,7 @@ class ComboChartConfig(ChartConfig):
     """
 
     # Combo-specific settings
-    series: list[dict] = dataclasses.field(default_factory=list)
+    series: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     column_gap: float = 0.20
 
     # Labels
@@ -306,7 +307,7 @@ class PieChartConfig(ChartConfig):
         ... )
     """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate pie-specific settings."""
         if not 0 <= self.inner_radius < 1:
             raise ValueError(
@@ -369,7 +370,7 @@ class BubbleChartConfig(ChartConfig):
         ... )
     """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate bubble-specific settings."""
         if self.min_radius < 0 or self.max_radius < 0:
             raise ValueError("min_radius and max_radius cannot be negative")
@@ -430,7 +431,7 @@ class RadarChartConfig(ChartConfig):
         ... )
     """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate radar-specific settings."""
         if not 0 < self.radius <= 1:
             raise ValueError("radius must be between 0 (exclusive) and 1 (inclusive)")

--- a/charted/charts/__init__.py
+++ b/charted/charts/__init__.py
@@ -35,7 +35,7 @@ __all__ = [
 ]
 
 
-def _CHART_CLASSES() -> dict:
+def _CHART_CLASSES() -> dict[str, type[Chart]]:
     """Return a mapping of chart type names to their classes.
 
     Used by Chart.from_config() to instantiate the right subclass.

--- a/charted/charts/annotations.py
+++ b/charted/charts/annotations.py
@@ -26,14 +26,18 @@ Example:
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 from charted.constants import (
     REFERENCE_LINE_WIDTH,
 )
 from charted.html.element import Element, Path, Rect, Text
 
+if TYPE_CHECKING:
+    from charted.charts.chart import Chart
 
-def _project(chart, x: float, y: float) -> tuple[float, float]:
+
+def _project(chart: Chart, x: float, y: float) -> tuple[float, float]:
     """Reproject a data point into plot-area-local pixel coordinates.
 
     The y-axis is flipped (high values at the top), matching the convention
@@ -78,7 +82,7 @@ class LineAnnotation:
         """Legacy vertical reference line spanning the full plot height."""
         return cls((value, 0), (value, 0), dashed=True, _ref_line="v", _ref_value=value)
 
-    def render(self, chart) -> Element:
+    def render(self, chart: Chart) -> Element:
         color = self.color or chart.theme.resolved_reference_line_color
         width = (
             self.width
@@ -86,9 +90,11 @@ class LineAnnotation:
             else chart.theme.resolved_reference_line_width
         )
         if self._ref_line == "h":
+            assert self._ref_value is not None
             y = chart.plot_height - chart.y_axis.reproject(self._ref_value)
             return self._dashed_path(f"M0 {y} h{chart.plot_width}", color, width)
         if self._ref_line == "v":
+            assert self._ref_value is not None
             x = chart.x_axis.reproject(self._ref_value)
             return self._dashed_path(f"M{x} 0 v{chart.plot_height}", color, width)
 
@@ -135,7 +141,7 @@ class BoxAnnotation:
     color: str | None = None
     opacity: float = 0.15
 
-    def render(self, chart) -> Element:
+    def render(self, chart: Chart) -> Element:
         x0, _ = _project(chart, self.x_range[0], 0)
         x1, _ = _project(chart, self.x_range[1], 0)
         _, y0 = _project(chart, 0, self.y_range[0])
@@ -174,7 +180,7 @@ class LabelAnnotation:
     font_size: float = 11.0
     text_anchor: str = "middle"
 
-    def render(self, chart) -> Element:
+    def render(self, chart: Chart) -> Element:
         x, y = _project(chart, *self.point)
         color = self.color or chart.theme.resolved_axis_title_color
         return Text(

--- a/charted/charts/area.py
+++ b/charted/charts/area.py
@@ -5,13 +5,14 @@ Shows one or more series as filled regions under the line.
 
 from __future__ import annotations
 
+from typing import Any
+
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path
 from charted.themes.core import Theme
 from charted.utils.curves import VALID_CURVES, curve_path
-from charted.utils.series_style import SeriesStyleConfig
-from charted.utils.types import Labels, Vector, Vector2D
+from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
 
 
 class AreaChart(Chart):
@@ -62,8 +63,8 @@ class AreaChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list | None = None,
-        reference_lines: list[dict] | None = None,
+        annotations: list[Any] | None = None,
+        reference_lines: list[dict[str, Any]] | None = None,
         colors: list[str] | None = None,
         domain_padding: float | None = None,
     ):

--- a/charted/charts/axes.py
+++ b/charted/charts/axes.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import math
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from charted.constants import DEFAULT_PADDING
-from charted.html.element import G, Path, Text
+from charted.html.element import Element, G, Path, Text
 from charted.utils.defaults import DEFAULT_FONT, DEFAULT_FONT_SIZE
 from charted.utils.exceptions import InvalidDataError
 from charted.utils.helpers import (
@@ -19,18 +22,37 @@ from charted.utils.types import (
 )
 from charted.utils.value_format import format_value
 
+if TYPE_CHECKING:
+    from charted.charts.scales import Scale
+
+
+class _AxisParent(Protocol):
+    """Structural type for the chart object an axis renders against.
+
+    The axis only ever reads these layout attributes off its parent chart; the
+    Protocol documents that contract without constraining concrete parents.
+    """
+
+    plot_width: float
+    plot_height: float
+    left_padding: float
+    top_padding: float
+    x_label_rotation: tuple[float, float] | None
+
 
 class Axis(G):
+    parent: _AxisParent
+
     def __init__(
         self,
-        parent: object,
+        parent: _AxisParent,
         data: Vector2D | None = None,
         labels: list[str] | None = None,
         stacked: bool = False,
         zero_index: bool = True,
         config: str | None = None,
         pad_labels: bool = True,
-        scale: object | None = None,
+        scale: Scale | None = None,
     ):
         if not data and not labels:
             raise InvalidDataError("Need labels or data.")
@@ -40,7 +62,7 @@ class Axis(G):
             data = [[i for i in range(len(labels))]]
 
         self.stacked = stacked
-        self.data = data
+        self.data: Vector2D | None = data
         self.parent = parent
         # A None scale means the default LinearScale: existing behaviour is
         # preserved byte-for-byte. Non-linear scales (log/time) own their tick
@@ -55,20 +77,27 @@ class Axis(G):
         self.config = config
         self.add_children(self.grid_lines, self.axis_labels)
 
-    def _init_with_scale(self, data, labels, zero_index) -> None:
+    def _init_with_scale(
+        self,
+        data: Vector2D | None,
+        labels: list[str] | None,
+        zero_index: bool,
+    ) -> None:
         """Set tick values and labels from a non-linear scale."""
         from charted.utils.types import AxisDimension
 
-        tick_values = self.scale.ticks()
+        scale = cast("Scale", self.scale)
+        tick_values = scale.ticks()
         self.axis_dimension = AxisDimension(
-            self.scale.min_value, self.scale.max_value, len(tick_values)
+            scale.min_value, scale.max_value, len(tick_values)
         )
-        self._values = list(tick_values)
-        self._grid_line_values = list(tick_values)
+        self._values: Vector = list(tick_values)
+        self._grid_line_values: Vector = list(tick_values)
         # Scale-provided labels (e.g. formatted dates) take priority.
-        if hasattr(self.scale, "tick_labels"):
+        if hasattr(scale, "tick_labels"):
             self._labels = [
-                calculate_text_dimensions(text) for text in self.scale.tick_labels()
+                calculate_text_dimensions(text)
+                for text in cast("Any", scale).tick_labels()
             ]
         else:
             self.labels = [str(v) for v in tick_values]
@@ -112,11 +141,14 @@ class Axis(G):
         has_labels: bool = False,
         zero_index: bool = True,
     ) -> AxisDimension:
+        assert data is not None
         count = len(data[0])
 
+        min_value: float
+        max_value: float
         if stacked:
-            min_values = [0] * count
-            max_values = [0] * count
+            min_values: list[float] = [0] * count
+            max_values: list[float] = [0] * count
             for series in data:
                 for n in range(count):
                     if series[n] < 0:
@@ -153,12 +185,12 @@ class Axis(G):
         labels: list[str] | None = None,
         zero_index: bool = True,
         stacked: bool | None = None,
-    ) -> tuple[AxisDimension, list[float]]:
+    ) -> tuple[AxisDimension, list[float], list[float]]:
         axd = cls.calculate_axis_dimensions(
             data=data,
             has_labels=labels is not None,
             zero_index=zero_index,
-            stacked=stacked,
+            stacked=bool(stacked),
         )
 
         if labels is not None:
@@ -169,7 +201,7 @@ class Axis(G):
             # Grid lines use full range from min to max for proper rendering
             min_val = min(values)
             max_val = max(values)
-            grid_line_values = list(range(int(min_val), int(max_val) + 1))
+            grid_line_values: list[float] = list(range(int(min_val), int(max_val) + 1))
             return (axd, values, grid_line_values)
 
         denominators = common_denominators(axd.min_value, axd.max_value)
@@ -226,6 +258,9 @@ class Axis(G):
     def reverse(self, value: float) -> float:
         raise Exception("reverse not implemented for instance of Axis.")
 
+    def reproject(self, value: float) -> float:
+        raise Exception("reproject not implemented for instance of Axis.")
+
     @property
     def zero(self) -> float:
         # Zero has no meaning on a log scale (and may be outside a time
@@ -235,11 +270,13 @@ class Axis(G):
         return self.reproject(0)
 
     @property
-    def grid_lines(self) -> Path:
+    def grid_lines(self) -> Element | None:
         raise Exception("grid_lines not implemented for instance of Axis.")
 
     @staticmethod
-    def _split_grid_config(config) -> tuple[dict, dict]:
+    def _split_grid_config(
+        config: str | dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Split a grid config into (major_attrs, minor_params).
 
         A string config becomes the historical single-weight attrs with no
@@ -293,6 +330,7 @@ class Axis(G):
         This replaces the tuple (data, labels, zero_index) which was prone to
         ordering errors. Using AxisValues provides self-documenting field names.
         """
+        assert axis_values.data is not None
         self.axis_dimension, self._values, self._grid_line_values = (
             self.calculate_axis_values(
                 data=axis_values.data,
@@ -326,9 +364,10 @@ class Axis(G):
         return self._labels
 
     @labels.setter
-    def labels(self, labels: Vector | list[str] = None) -> None:
+    def labels(self, labels: Vector | list[str] | None = None) -> None:
+        resolved: list[str]
         if not labels:
-            labels = []
+            resolved = []
             precision = 0
             for label in self.values:
                 if "." in str(label):
@@ -336,10 +375,10 @@ class Axis(G):
                     if float(decimal_value) > 0:
                         precision = 1
             for label in self.values:
-                labels.append(format_value(label, decimals=precision))
+                resolved.append(format_value(label, decimals=precision))
         else:
-            labels = [*labels]
-        self._labels = [calculate_text_dimensions(label) for label in labels]
+            resolved = [str(label) for label in labels]
+        self._labels = [calculate_text_dimensions(label) for label in resolved]
 
     @property
     def count(self) -> int:
@@ -407,7 +446,7 @@ class XAxis(Axis):
         return stride
 
     @property
-    def grid_lines(self) -> Path:
+    def grid_lines(self) -> Element | None:
         if not self.config:
             return None
 
@@ -419,7 +458,7 @@ class XAxis(Axis):
         # relative to zero (value/range), so tick coordinates need to be
         # shifted right by reproject(abs(min_value)) to land at absolute
         # positions within the plot.
-        dx = 0
+        dx: float = 0
         min_v = self.axis_dimension.min_value
         if self.stacked and min_v < 0:
             dx = self.reproject(abs(min_v))
@@ -478,12 +517,12 @@ class XAxis(Axis):
             group_kwargs["font_weight"] = font_weight
         labels = G(**group_kwargs)
 
-        rotation_angle = 0
+        rotation_angle: float = 0
         if self.parent.x_label_rotation:
             rotation_angle, _ = self.parent.x_label_rotation
 
         # Same absolute-position compensation as grid_lines.
-        dx = 0
+        dx: float = 0
         min_v = self.axis_dimension.min_value
         if self.stacked and min_v < 0:
             dx = self.reproject(abs(min_v))
@@ -549,7 +588,7 @@ class YAxis(Axis):
         else:
             values = self.values
 
-        offset = 0
+        offset: float = 0
         if self.stacked and self.axis_dimension.min_value < 0:
             offset = self.axis_dimension.min_value
 
@@ -565,7 +604,7 @@ class YAxis(Axis):
         return [self.reproject(i + abs(offset)) for i in reversed(values)]
 
     @property
-    def grid_lines(self) -> Path:
+    def grid_lines(self) -> Element | None:
         if not self.config:
             return None
 

--- a/charted/charts/bar.py
+++ b/charted/charts/bar.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from charted.charts.chart import Chart
 from charted.config import get_bar_gap
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
-from charted.html.element import G, Path, Text
+from charted.html.element import Element, G, Path, Text
 from charted.themes.core import Theme
 from charted.utils.exceptions import NoDataError
-from charted.utils.series_style import SeriesStyleConfig
-from charted.utils.types import Labels, Vector, Vector2D
+from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
 
 
 class BarChart(Chart):
@@ -42,8 +43,8 @@ class BarChart(Chart):
     def __init__(
         self,
         data: Vector | Vector2D,
-        labels: Labels = None,
-        bar_gap: float = None,
+        labels: Labels | None = None,
+        bar_gap: float | None = None,
         width: float = DEFAULT_CHART_WIDTH,
         height: float = DEFAULT_CHART_HEIGHT,
         zero_index: bool = True,
@@ -59,10 +60,10 @@ class BarChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list | None = None,
-        reference_lines: list[dict] | None = None,
+        annotations: list[Any] | None = None,
+        reference_lines: list[dict[str, Any]] | None = None,
         colors: list[str] | None = None,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, Any] | None = None,
         legend: str = "none",
         category_label_max_width: float | None = None,
         category_patterns: list[str] | bool | None = None,
@@ -74,8 +75,9 @@ class BarChart(Chart):
         self.bar_gap = bar_gap
         self.x_stacked = x_stacked
 
+        x_data: Vector2D
         if not isinstance(data, list) or not data or isinstance(data[0], (int, float)):
-            x_data = [data]
+            x_data = cast("Vector2D", [data])
         else:
             x_data = data
 
@@ -84,6 +86,7 @@ class BarChart(Chart):
 
         num_bars = len(x_data[0]) if x_data else 0
         num_series = len(x_data) if x_data else 0
+        y_data: Vector2D
         if num_bars <= 1:
             y_data = [[0, 1] for _ in range(num_series)] if num_series > 0 else [[0, 1]]
         else:
@@ -125,11 +128,11 @@ class BarChart(Chart):
         # calculates from labels (32.0). We need to recreate the grid Path
         # with correct values.
         if self.y_axis and self.y_axis.config:
-            self.y_axis.children[0] = self.y_axis.grid_lines
+            self.y_axis.children[0] = cast("Element", self.y_axis.grid_lines)
             self.y_axis.children[1] = self.y_axis.axis_labels
 
         if self.x_axis and self.x_axis.config:
-            self.x_axis.children[0] = self.x_axis.grid_lines
+            self.x_axis.children[0] = cast("Element", self.x_axis.grid_lines)
             self.x_axis.children[1] = self.x_axis.axis_labels
 
     def _value_label_data(self) -> Vector2D:
@@ -140,7 +143,7 @@ class BarChart(Chart):
     def y_height(self) -> float:
         return self.plot_height / (self.y_count + (self.y_count + 1) * self.bar_gap)
 
-    def get_base_transform(self) -> list:
+    def get_base_transform(self) -> list[str]:
         return []
 
     @property
@@ -161,7 +164,7 @@ class BarChart(Chart):
         # leftward from x_offset) land at the correct zero-relative position.
         # Non-stacked uses absolute zero_x from the reprojection and doesn't
         # need this compensation.
-        dx = 0
+        dx: float = 0
         if self.x_stacked and self.x_axis.axis_dimension.min_value < 0:
             dx = self.x_axis.reproject(abs(self.x_axis.axis_dimension.min_value))
 
@@ -176,14 +179,18 @@ class BarChart(Chart):
             # value axis (x here, y in ColumnChart). x_offsets is pre-computed
             # and already reprojected by Chart.x_offsets setter.
             for series_idx, (x_values_series, x_offsets_series, color) in enumerate(
-                zip(self.x_values, self.x_offsets, self.colors)
+                zip(
+                    self.x_values,
+                    cast("Vector2D", self.x_offsets),
+                    self.colors,
+                )
             ):
                 # Apply fill override from series_styles
                 fill = color
                 if self.series_styles and series_idx < len(self.series_styles):
                     style = self.series_styles[series_idx] or {}
                     if style.get("fill"):
-                        fill = style["fill"]
+                        fill = cast("str", style["fill"])
 
                 paths = []
                 for bar_idx, (x, x_offset_val) in enumerate(
@@ -212,7 +219,7 @@ class BarChart(Chart):
                 if self.series_styles and series_idx < len(self.series_styles):
                     style = self.series_styles[series_idx] or {}
                     if style.get("fill"):
-                        fill = style["fill"]
+                        fill = cast("str", style["fill"])
 
                 has_fill_override = fill != color
                 per_bar = (
@@ -280,7 +287,9 @@ class BarChart(Chart):
                         # horizontally inside its own segment, which runs from
                         # the cumulative offset to offset+value.
                         slot_y = start_y + bar_idx * (slot_height + gap)
-                        x_offset_val = self.x_offsets[series_idx][bar_idx]
+                        x_offset_val = cast("Vector2D", self.x_offsets)[series_idx][
+                            bar_idx
+                        ]
                         seg_left = min(x_offset_val, x_offset_val + x)
                         seg_width = abs(x)
                         bars_g.add_child(

--- a/charted/charts/box.py
+++ b/charted/charts/box.py
@@ -5,6 +5,8 @@ Displays median, quartiles, and outliers for one or more data series.
 
 from __future__ import annotations
 
+from typing import Any
+
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path, Rect, Text
@@ -19,7 +21,7 @@ def _quartiles(data: list[float]) -> tuple[float, float, float, float, float]:
     if n == 0:
         return (0, 0, 0, 0, 0)
 
-    def median(arr) -> float:
+    def median(arr: list[float]) -> float:
         if not arr:
             return 0
         mid = len(arr) // 2
@@ -60,7 +62,7 @@ class BoxPlot(Chart):
         title: str | None = None,
         theme: Theme | None = None,
         series_names: list[str] | None = None,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, Any] | None = None,
         legend: str = "none",
     ):
         self._raw_data = data

--- a/charted/charts/bubble.py
+++ b/charted/charts/bubble.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from charted.charts.scatter import ScatterChart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import Circle, G, Path, Text
@@ -103,7 +105,7 @@ class BubbleChart(ScatterChart):
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
         quadrant_labels: list[str] | None = None,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, Any] | None = None,
         legend: str = "none",
         domain_padding: float | None = None,
     ):
@@ -120,7 +122,7 @@ class BubbleChart(ScatterChart):
         # against every series length, not just the first.
         is_multi_series = bool(y_data) and isinstance(y_data[0], list)
         if is_multi_series:
-            series_lengths = [len(series) for series in y_data]
+            series_lengths = [len(cast("list[float]", series)) for series in y_data]
         else:
             series_lengths = [len(y_data)]
         for series_idx, point_count in enumerate(series_lengths):
@@ -290,10 +292,10 @@ class BubbleChart(ScatterChart):
         if self.max_radius <= 0:
             return {"x": 0.0, "y": 0.0}
 
-        def flat(data) -> list[float]:
+        def flat(data: Vector | Vector2D) -> list[float]:
             if data and isinstance(data[0], list):
                 return [v for row in data for v in row]
-            return list(data) if data else []
+            return list(cast("Vector", data)) if data else []
 
         # Rough plot-area estimates: title/axis chrome eats vertical space and
         # the value-axis gutter plus any reserved legend band eats horizontal
@@ -329,7 +331,13 @@ class BubbleChart(ScatterChart):
             "y": axis_fraction(flat(y_data), plot_h),
         }
 
-    def _anchor_axis_data(self, data, fixed_range, zero_baseline=False, stacked=False):
+    def _anchor_axis_data(
+        self,
+        data: Vector2D,
+        fixed_range: tuple[float, float] | None,
+        zero_baseline: bool = False,
+        stacked: bool = False,
+    ) -> Vector2D:
         """Apply the per-axis radius-aware pad before delegating to the base.
 
         When the caller passed an explicit ``domain_padding`` we leave the base
@@ -387,6 +395,7 @@ class BubbleChart(ScatterChart):
         return _lerp_color(base, bg, 0.7), base
 
     def _hue_color_at(self, value: float) -> str:
+        assert self.hue is not None
         lo = min(self.hue)
         hi = max(self.hue)
         t = 0.0 if hi == lo else (value - lo) / (hi - lo)
@@ -422,7 +431,7 @@ class BubbleChart(ScatterChart):
             if self.series_styles and series_idx < len(self.series_styles):
                 style = self.series_styles[series_idx] or {}
                 if style.get("fill"):
-                    fill = style["fill"]
+                    fill = cast("str", style["fill"])
 
             series = G(fill=fill)
             x_offset = self.x_offset
@@ -574,6 +583,7 @@ class BubbleChart(ScatterChart):
 
         bar_w = self._HUE_BAR_WIDTH
         bar_h = self._HUE_BAR_HEIGHT
+        assert self.hue is not None
         lo = min(self.hue)
         hi = max(self.hue)
 
@@ -614,7 +624,7 @@ class BubbleChart(ScatterChart):
                 )
             )
 
-    def to_config(self) -> dict:
+    def to_config(self) -> dict[str, Any]:
         cfg = super().to_config()
         cfg["sizes"] = list(self.sizes)
         cfg["min_radius"] = self.min_radius

--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -312,7 +312,7 @@ class Chart(SeriesLegend, Svg):
         if "y_data" in valid_params and "y_data" not in filtered and "data" in merged:
             filtered["y_data"] = merged["data"]
 
-        return cast("Chart", chart_cls(**filtered))
+        return chart_cls(**filtered)
 
     @staticmethod
     def _rebuild_annotations(annotations: list[Any]) -> list[Any]:

--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -4,6 +4,10 @@ Refactored to extract validation, layout, and rendering utilities into
 separate modules to address God Class architectural debt (Issue #64).
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
 from charted.charts.axes import XAxis, YAxis
 from charted.constants import (
     AXIS_BORDER_COLOR,
@@ -11,7 +15,7 @@ from charted.constants import (
     DEFAULT_CHART_HEIGHT,
     DEFAULT_CHART_WIDTH,
 )
-from charted.html.element import ClipPath, Defs, G, Path, Rect, Svg, Text
+from charted.html.element import Child, ClipPath, Defs, G, Path, Rect, Svg, Text
 from charted.themes.core import Theme
 from charted.utils.color_manager import ColorManager
 from charted.utils.data_model import DataModel
@@ -30,6 +34,11 @@ from charted.utils.types import (
     Vector,
     Vector2D,
 )
+
+if TYPE_CHECKING:
+    from charted.charts.axes import _AxisParent
+    from charted.charts.scales import Scale
+    from charted.html.element import Title
 
 
 class Chart(SeriesLegend, Svg):
@@ -67,6 +76,13 @@ class Chart(SeriesLegend, Svg):
     y_stacked: bool = False
     render_axes: bool = True
     pad_x_labels: bool = True
+
+    # Instance attributes assigned in __init__ (declared here so mypy can infer
+    # their type at every read site; conditional assignment otherwise leaves the
+    # type undeterminable).
+    theme: Theme
+    _title: MeasuredText | None
+    _subtitle: MeasuredText | None
 
     # =========================================================================
     # Core Representation Methods
@@ -152,7 +168,7 @@ class Chart(SeriesLegend, Svg):
                 f.write(self.svg)
         elif ext == ".png":
             try:
-                import cairosvg
+                import cairosvg  # type: ignore[import-untyped]
             except ImportError:
                 raise ImportError(
                     "PNG export requires cairosvg. "
@@ -164,7 +180,7 @@ class Chart(SeriesLegend, Svg):
                 f"Unsupported file extension '{ext}'. Supported: .svg, .png"
             )
 
-    def style(self, **kwargs) -> "Chart":
+    def style(self, **kwargs: Any) -> "Chart":
         """Fluently apply theme overrides.
 
         Args:
@@ -184,7 +200,7 @@ class Chart(SeriesLegend, Svg):
         self.theme = self.theme.compose(override)
         return self
 
-    def to_config(self) -> dict:
+    def to_config(self) -> dict[str, Any]:
         """Serialize chart configuration to a dict.
 
         Returns a dict with all constructor parameters needed to
@@ -195,7 +211,7 @@ class Chart(SeriesLegend, Svg):
         """
         import dataclasses
 
-        cfg = {
+        cfg: dict[str, Any] = {
             "chart_type": self.__class__.__name__,
             "width": self._width,
             "height": self._height,
@@ -232,7 +248,7 @@ class Chart(SeriesLegend, Svg):
         return cfg
 
     @staticmethod
-    def _serialize_annotation(a):
+    def _serialize_annotation(a: Any) -> Any:
         """Serialize one annotation to a JSON-friendly dict.
 
         Tags the dict with its class name and strips private ``_ref_*`` fields
@@ -243,11 +259,15 @@ class Chart(SeriesLegend, Svg):
 
         if not dataclasses.is_dataclass(a):
             return a
-        data = {k: v for k, v in dataclasses.asdict(a).items() if not k.startswith("_")}
+        data = {
+            k: v
+            for k, v in dataclasses.asdict(cast("Any", a)).items()
+            if not k.startswith("_")
+        }
         return {"type": a.__class__.__name__, **data}
 
     @classmethod
-    def from_config(cls, config: dict, **overrides) -> "Chart":
+    def from_config(cls, config: dict[str, Any], **overrides: Any) -> "Chart":
         """Recreate a chart from a config dict.
 
         Merges ``overrides`` on top of ``config`` so agents can tweak
@@ -292,10 +312,10 @@ class Chart(SeriesLegend, Svg):
         if "y_data" in valid_params and "y_data" not in filtered and "data" in merged:
             filtered["y_data"] = merged["data"]
 
-        return chart_cls(**filtered)
+        return cast("Chart", chart_cls(**filtered))
 
     @staticmethod
-    def _rebuild_annotations(annotations: list) -> list:
+    def _rebuild_annotations(annotations: list[Any]) -> list[Any]:
         """Reconstruct annotation objects from their serialized dict form.
 
         ``to_config()`` serializes each annotation as
@@ -322,7 +342,7 @@ class Chart(SeriesLegend, Svg):
         # Fields that are (x, y) / (min, max) pairs and must be tuples.
         tuple_fields = {"start", "end", "x_range", "y_range", "point"}
 
-        rebuilt: list = []
+        rebuilt: list[Any] = []
         for a in annotations:
             # Already an annotation object (not a serialized dict): keep as-is.
             if not isinstance(a, dict):
@@ -366,22 +386,22 @@ class Chart(SeriesLegend, Svg):
         title: str | None = None,
         subtitle: str | None = None,
         subtitle_leading: float = 8.0,
-        theme: Theme | str | dict | None = None,
+        theme: Theme | str | dict[str, Any] | None = None,
         chart_type: str | None = None,
         x_label: str | None = None,
         y_label: str | None = None,
         data_labels: list[str] | list[list[str]] | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list | None = None,
+        annotations: list[Any] | None = None,
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict] | None = None,
+        reference_lines: list[dict[str, Any]] | None = None,
         colors: list[str] | None = None,
         x_range: tuple[float, float] | None = None,
         y_range: tuple[float, float] | None = None,
         domain_padding: float | None = None,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, Any] | None = None,
         legend: str = "none",
         category_label_max_width: float | None = None,
         category_patterns: list[str] | bool | None = None,
@@ -416,8 +436,12 @@ class Chart(SeriesLegend, Svg):
 
         # Optional fixed scale domains / data-domain padding. All default to
         # None, which preserves the historical auto-fit-from-data behaviour.
-        self._x_range = tuple(x_range) if x_range is not None else None
-        self._y_range = tuple(y_range) if y_range is not None else None
+        self._x_range: tuple[float, float] | None = (
+            cast("tuple[float, float]", tuple(x_range)) if x_range is not None else None
+        )
+        self._y_range: tuple[float, float] | None = (
+            cast("tuple[float, float]", tuple(y_range)) if y_range is not None else None
+        )
         self._domain_padding = domain_padding
 
         # Record the requested scale specs (string or Scale instance) for
@@ -449,10 +473,12 @@ class Chart(SeriesLegend, Svg):
                 array_len = 0
             x_labels = DataModel.create_default_labels(array_len)
 
-        # Initialize DataModel for data validation and normalization
+        # Initialize DataModel for data validation and normalization. DataModel
+        # accepts and normalizes 1D Vector input at runtime; its declared type is
+        # Vector2D, so cast the possibly-1D locals to satisfy the checker.
         self.data_model = DataModel(
-            x_data=x_data,
-            y_data=y_data,
+            x_data=cast("Vector2D | None", x_data),
+            y_data=cast("Vector2D | None", y_data),
             x_labels=x_labels,
             y_labels=y_labels,
             zero_index=zero_index,
@@ -468,11 +494,11 @@ class Chart(SeriesLegend, Svg):
         self._data_labels = data_labels
         self._value_label_config = self._normalize_value_labels(value_labels)
         self._annotations = list(annotations) if annotations else []
-        self._h_lines = h_lines or []
-        self._v_lines = v_lines or []
+        self._h_lines: list[float] | None = h_lines or []
+        self._v_lines: list[float] | None = v_lines or []
 
         # Parse reference_lines convenience API into h_lines/v_lines + labels
-        self._reference_line_labels: list[dict] = []
+        self._reference_line_labels: list[dict[str, Any]] = []
         if reference_lines:
             from charted.utils.exceptions import ValidationError
 
@@ -579,7 +605,7 @@ class Chart(SeriesLegend, Svg):
         # Apply fixed-domain (x_range/y_range) or fractional domain_padding by
         # anchoring the data the axes derive their min/max from. None leaves the
         # axis data untouched, so the auto-fit domain is unchanged.
-        value_axis = self._BAR_VALUE_AXIS.get(chart_type)
+        value_axis = self._BAR_VALUE_AXIS.get(cast("str", chart_type))
         x_axis_data = self._anchor_axis_data(
             self.x_data,
             self._x_range,
@@ -598,9 +624,11 @@ class Chart(SeriesLegend, Svg):
         # existing single-weight renders are unchanged byte-for-byte.
         grid_config = self._build_grid_config()
 
-        # Initialize axes
+        # Initialize axes. Chart satisfies the _AxisParent layout contract
+        # structurally; the cast bridges its read-only property accessors to the
+        # protocol's plain-attribute declarations.
         self.x_axis = XAxis(
-            parent=self,
+            parent=cast("_AxisParent", self),
             data=x_axis_data,
             labels=x_labels,
             stacked=self.x_stacked,
@@ -609,18 +637,18 @@ class Chart(SeriesLegend, Svg):
                 if (x_data is not None and x_labels is not None)
                 else self.zero_index
             ),
-            config=grid_config,
+            config=cast("str | None", grid_config),
             pad_labels=self.pad_x_labels,
             scale=x_scale_inst,
         )
 
         self.y_axis = YAxis(
-            parent=self,
+            parent=cast("_AxisParent", self),
             data=y_axis_data,
             labels=y_labels,
             stacked=self.y_stacked,
             zero_index=self.zero_index,
-            config=grid_config,
+            config=cast("str | None", grid_config),
             scale=y_scale_inst,
         )
 
@@ -777,7 +805,12 @@ class Chart(SeriesLegend, Svg):
         for pattern in self._pattern_defs():
             defs.add_child(pattern)
 
-        children = [self.container, self.title, self.subtitle_element, defs]
+        children: list[Child | None] = [
+            self.container,
+            self.title,
+            self.subtitle_element,
+            defs,
+        ]
         if self.render_axes:
             children += [self.y_axis, self.x_axis, self.zero_line]
         children += [self.representation, self.legend]
@@ -818,7 +851,7 @@ class Chart(SeriesLegend, Svg):
         colors = getattr(self, "colors", None) or []
         return len(colors)
 
-    def _pattern_defs(self) -> list:
+    def _pattern_defs(self) -> list[Any]:
         """Build one ``<pattern>`` def per (category, pattern) the chart uses.
 
         Returns an empty list unless ``category_patterns`` was enabled, so the
@@ -832,7 +865,7 @@ class Chart(SeriesLegend, Svg):
         from charted.utils.patterns import build_pattern
 
         colors = getattr(self, "colors", None) or []
-        defs: list = []
+        defs: list[Any] = []
         for idx, color in enumerate(colors):
             name = cycle[idx % len(cycle)]
             defs.append(build_pattern(self._pattern_id(idx), name, color))
@@ -853,7 +886,7 @@ class Chart(SeriesLegend, Svg):
             return color
         return f"url(#{self._pattern_id(index)})"
 
-    def _filled_outline_attrs(self) -> dict:
+    def _filled_outline_attrs(self) -> dict[str, Any]:
         """Stroke attributes to apply to a filled shape, or ``{}`` when off.
 
         Reads the theme's ``filled_shape_outline``; when no outline colour is
@@ -883,9 +916,14 @@ class Chart(SeriesLegend, Svg):
     }
 
     @classmethod
-    def _reject_unsupported_scales(cls, chart_type, x_scale_inst, y_scale_inst) -> None:
+    def _reject_unsupported_scales(
+        cls,
+        chart_type: str | None,
+        x_scale_inst: Scale | None,
+        y_scale_inst: Scale | None,
+    ) -> None:
         """Raise ValueError for log/time scales on a bar/column value axis."""
-        value_axis = cls._BAR_VALUE_AXIS.get(chart_type)
+        value_axis = cls._BAR_VALUE_AXIS.get(cast("str", chart_type))
         if value_axis is None:
             return
         scale = x_scale_inst if value_axis == "x" else y_scale_inst
@@ -912,12 +950,12 @@ class Chart(SeriesLegend, Svg):
         """Convert date/datetime/ISO-string x-data into epoch seconds."""
         from charted.charts.scales import _to_epoch
 
-        def conv(seq):
+        def conv(seq: Vector) -> Vector:
             return [_to_epoch(v) for v in seq]
 
         if x_data and isinstance(x_data[0], list):
             return [conv(row) for row in x_data]
-        return conv(x_data)
+        return conv(cast("Vector", x_data))
 
     def _anchor_axis_data(
         self,
@@ -982,6 +1020,9 @@ class Chart(SeriesLegend, Svg):
             # the data alone so the axis keeps its own degenerate-domain logic.
             if span == 0:
                 return data
+            # When fixed_range is None the constructor guard guarantees
+            # _domain_padding is set; assert it for the type checker.
+            assert self._domain_padding is not None
             pad = span * self._domain_padding
             if zero_baseline:
                 # Keep the zero baseline pinned: only add headroom on the side
@@ -1012,7 +1053,7 @@ class Chart(SeriesLegend, Svg):
         # data reach lo/hi without altering the plotted points themselves.
         return [*[list(row) for row in data], [lo, hi]]
 
-    def _build_grid_config(self):
+    def _build_grid_config(self) -> str | dict[str, Any]:
         """Assemble the gridline config passed to each axis.
 
         Returns the plain grid colour string when the theme requests no
@@ -1030,7 +1071,7 @@ class Chart(SeriesLegend, Svg):
         if width is None and dasharray is None and divisions <= 0:
             return color
 
-        config = {
+        config: dict[str, Any] = {
             "stroke": color,
             "stroke_dasharray": dasharray if dasharray is not None else "None",
         }
@@ -1042,7 +1083,7 @@ class Chart(SeriesLegend, Svg):
             config["minor_stroke_width"] = theme.resolved_minor_grid_width
         return config
 
-    def _build_scale(self, spec: object | None, data: Vector2D):
+    def _build_scale(self, spec: object | None, data: Vector2D) -> Scale | None:
         """Construct a Scale instance for an axis from its data domain.
 
         Returns None for the default linear case so the axis keeps its
@@ -1059,7 +1100,7 @@ class Chart(SeriesLegend, Svg):
             domain_min, domain_max = min(flat), max(flat)
         if isinstance(spec, Scale):
             return spec
-        return make_scale(spec, domain_min, domain_max)
+        return make_scale(cast("str | Scale | None", spec), domain_min, domain_max)
 
     @property
     def x_scale(self) -> str:
@@ -1119,7 +1160,7 @@ class Chart(SeriesLegend, Svg):
         """Get plot area height from LayoutEngine."""
         return self.layout.plot_height
 
-    def get_base_transform(self) -> list:
+    def get_base_transform(self) -> list[str]:
         """Get base transformation from LayoutEngine."""
         return self.layout.get_base_transform()
 
@@ -1177,7 +1218,7 @@ class Chart(SeriesLegend, Svg):
         )
 
     @property
-    def title(self) -> MeasuredText | None:
+    def title(self) -> Text | None:
         if not self._title:
             return None
         return Text(
@@ -1307,7 +1348,7 @@ class Chart(SeriesLegend, Svg):
     # =========================================================================
 
     @property
-    def zero_line(self) -> Path:
+    def zero_line(self) -> Path | None:
         """Create zero line for charts with negative values."""
         from charted.utils.rendering import create_zero_line_path
 
@@ -1382,7 +1423,7 @@ class Chart(SeriesLegend, Svg):
         from charted.utils.rendering import create_legend
 
         # Pass legend config as dict or Theme object
-        legend_config = {
+        legend_config: dict[str, Any] = {
             "font_size": self.theme.legend_font_size,
             "position": self.theme.legend_position,
             "font_family": self.theme.legend_font_family,
@@ -1391,7 +1432,7 @@ class Chart(SeriesLegend, Svg):
         }
 
         return create_legend(
-            series_names=self.series_names,
+            series_names=cast("list[str]", self.series_names),
             colors=self.colors,
             theme_config=legend_config,
             plot_left=self.left_padding,
@@ -1404,7 +1445,7 @@ class Chart(SeriesLegend, Svg):
     # Introspection
     # =========================================================================
 
-    def describe(self) -> dict:
+    def describe(self) -> dict[str, Any]:
         """Return a structured dictionary of chart metadata.
 
         Useful for AI agents that need to reason about a chart they just
@@ -1498,7 +1539,7 @@ class Chart(SeriesLegend, Svg):
     # Reference Lines & Axis Labels
     # =========================================================================
 
-    def _collect_legacy_reference_lines(self) -> list:
+    def _collect_legacy_reference_lines(self) -> list[Any]:
         """Build the legacy ``h_lines`` / ``v_lines`` reference-line layer.
 
         These are expressed as dashed full-span ``LineAnnotation`` objects so
@@ -1509,14 +1550,14 @@ class Chart(SeriesLegend, Svg):
         """
         from charted.charts.annotations import LineAnnotation
 
-        annotations: list = []
+        annotations: list[Any] = []
         if self._h_lines:
             annotations.extend(LineAnnotation._h_line(v) for v in self._h_lines)
         if self._v_lines:
             annotations.extend(LineAnnotation._v_line(v) for v in self._v_lines)
         return annotations
 
-    def _collect_annotations(self) -> list:
+    def _collect_annotations(self) -> list[Any]:
         """Build the full annotation list for this chart.
 
         Legacy reference lines (``h_lines`` / ``v_lines``) come first, in their
@@ -1640,9 +1681,9 @@ class Chart(SeriesLegend, Svg):
 
         return g
 
-    def _render_axis_labels(self) -> list:
+    def _render_axis_labels(self) -> list[Text]:
         """Render x-axis and y-axis title labels."""
-        elements = []
+        elements: list[Text] = []
         font_size = self.theme.title_font_size - 2
         font_family = self.theme.title_font_family
         font_color = self.theme.resolved_axis_title_color
@@ -1721,7 +1762,7 @@ class Chart(SeriesLegend, Svg):
             return f"Series {series_idx + 1}: {value}"
         return str(value)
 
-    def _tooltip_value(self, series_idx: int, point_idx: int):
+    def _tooltip_value(self, series_idx: int, point_idx: int) -> float | str:
         """Return the raw data value for a point (overridable per chart)."""
         data = self.y_data
         if series_idx < len(data) and point_idx < len(data[series_idx]):
@@ -1731,7 +1772,7 @@ class Chart(SeriesLegend, Svg):
             return value
         return ""
 
-    def _tooltip_title(self, series_idx: int, point_idx: int):
+    def _tooltip_title(self, series_idx: int, point_idx: int) -> "Title | None":
         """Return a ``Title`` element for a mark, or None when tooltips off."""
         if not self._tooltips:
             return None
@@ -1744,7 +1785,9 @@ class Chart(SeriesLegend, Svg):
     # =========================================================================
 
     @staticmethod
-    def _normalize_value_labels(spec: bool | str | dict | None) -> dict | None:
+    def _normalize_value_labels(
+        spec: bool | str | dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
         """Coerce the ``value_labels`` argument into a config dict or None.
 
         Accepted forms:

--- a/charted/charts/column.py
+++ b/charted/charts/column.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from charted.charts.chart import Chart
 from charted.config import get_column_gap
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path
 from charted.themes.core import Theme
-from charted.utils.series_style import SeriesStyleConfig
 from charted.utils.transform import translate
-from charted.utils.types import Labels, Vector, Vector2D
+from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
 
 
 class ColumnChart(Chart):
@@ -40,8 +41,8 @@ class ColumnChart(Chart):
     def __init__(
         self,
         data: Vector | Vector2D,
-        labels: Labels = None,
-        column_gap: float = None,
+        labels: Labels | None = None,
+        column_gap: float | None = None,
         width: float = DEFAULT_CHART_WIDTH,
         height: float = DEFAULT_CHART_HEIGHT,
         zero_index: bool = True,
@@ -57,12 +58,12 @@ class ColumnChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list | None = None,
+        annotations: list[Any] | None = None,
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict] | None = None,
+        reference_lines: list[dict[str, Any]] | None = None,
         colors: list[str] | None = None,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, Any] | None = None,
         legend: str = "none",
         category_patterns: list[str] | bool | None = None,
         domain_padding: float | None = None,
@@ -115,7 +116,7 @@ class ColumnChart(Chart):
 
     @property
     def representation(self) -> G:
-        dy = 0
+        dy: float = 0
         if self.y_axis.axis_dimension.min_value < 0:
             dy = self.y_axis.reproject(abs(self.y_axis.axis_dimension.min_value))
 
@@ -139,7 +140,7 @@ class ColumnChart(Chart):
                 if self.series_styles and series_idx < len(self.series_styles):
                     style = self.series_styles[series_idx] or {}
                     if style.get("fill"):
-                        fill = style["fill"]
+                        fill = cast("str", style["fill"])
                 draw_fill = (
                     self._category_fill(series_idx, fill) if fill == color else fill
                 )
@@ -173,7 +174,7 @@ class ColumnChart(Chart):
                 if self.series_styles and series_idx < len(self.series_styles):
                     style = self.series_styles[series_idx] or {}
                     if style.get("fill"):
-                        fill = style["fill"]
+                        fill = cast("str", style["fill"])
 
                 has_fill_override = fill != color
                 per_bar = (

--- a/charted/charts/combo.py
+++ b/charted/charts/combo.py
@@ -7,17 +7,19 @@ that scales to its own range and renders tick labels on the right.
 
 from __future__ import annotations
 
-from charted.charts.axes import YAxis
+from typing import Any, cast
+
+from charted.charts.axes import XAxis, YAxis, _AxisParent
 from charted.charts.chart import Chart
 from charted.charts.column import ColumnChart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path, Text
 from charted.themes.core import Theme
 from charted.utils.defaults import DEFAULT_FONT, DEFAULT_FONT_SIZE
-from charted.utils.line_renderer import LineRenderer
-from charted.utils.series_style import SeriesStyleConfig
+from charted.utils.layout_engine import LayoutEngine
+from charted.utils.line_renderer import LineRenderer, _LineHost
 from charted.utils.transform import translate
-from charted.utils.types import Labels
+from charted.utils.types import Labels, SeriesStyleConfig, Vector2D
 
 _BAR_TYPES = {"bar", "column"}
 _LINE_TYPES = {"line", "area"}
@@ -33,80 +35,89 @@ class _SeriesProxy:
     coordinate system.
     """
 
-    def __init__(self, parent: "ComboChart", indices: list[int], y_axis):
+    x_axis: XAxis
+    y_axis: YAxis
+
+    def __init__(self, parent: "ComboChart", indices: list[int], y_axis: YAxis) -> None:
         self._parent = parent
         self._indices = indices
-        self.y_axis = y_axis
-        self.x_axis = parent.x_axis
-        self.theme = parent.theme
-        self.layout = parent.layout
-        self.series_styles = (
+        self.y_axis: YAxis = y_axis
+        self.x_axis: XAxis = parent.x_axis
+        self.theme: Theme = parent.theme
+        self.layout: LayoutEngine = parent.layout
+        self.series_styles: list[SeriesStyleConfig] | None = (
             [parent.series_styles[i] for i in indices] if parent.series_styles else None
         )
 
     # --- subset data ---
     @property
-    def y_values(self):
+    def y_values(self) -> Vector2D:
         return [self._parent._reproject_series(i) for i in self._indices]
 
     @property
-    def y_offsets(self):
+    def y_offsets(self) -> Vector2D:
         # Combo never stacks; offsets are zero.
         return [[0.0] * len(self._parent.series[i]["data"]) for i in self._indices]
 
     @property
-    def x_values(self):
+    def x_values(self) -> Vector2D:
         return [self._parent.x_values[0] for _ in self._indices]
 
     @property
-    def colors(self):
+    def colors(self) -> list[str]:
         return [self._parent.colors[i] for i in self._indices]
 
     # --- pass-through layout/geometry ---
     @property
-    def plot_width(self):
+    def plot_width(self) -> float:
         return self._parent.plot_width
 
     @property
-    def plot_height(self):
+    def plot_height(self) -> float:
         return self._parent.plot_height
 
     @property
-    def x_count(self):
+    def x_count(self) -> int:
         return self._parent.x_count
 
     @property
-    def x_width(self):
+    def x_width(self) -> float:
         return self._parent.x_width
 
     @property
-    def x_offset(self):
+    def x_offset(self) -> float:
         return self._parent.x_offset
 
     @property
-    def left_padding(self):
+    def left_padding(self) -> float:
         return self._parent.left_padding
 
     @property
-    def top_padding(self):
+    def top_padding(self) -> float:
         return self._parent.top_padding
 
-    def get_base_transform(self):
+    def get_base_transform(self) -> list[str]:
         return self._parent.get_base_transform()
 
-    def _apply_stacking(self, y, y_offset):
+    def _apply_stacking(self, y: float, y_offset: float) -> float:
         return y
 
     # attributes the renderers probe with getattr
-    y_stacked = False
-    markers = False
-    _data_labels = None
+    y_stacked: bool = False
+    markers: bool = False
+    _data_labels: list[str] | list[list[str]] | None = None
 
 
-class _ColumnProxy(_SeriesProxy, ColumnChart):
+# The type:ignore[misc] on the class line below is needed because ColumnChart
+# (via Chart) assigns x_axis/y_axis in __init__ without a class-level
+# annotation, so mypy cannot reconcile their type across this proxy's two
+# bases. _SeriesProxy supplies the concrete XAxis/YAxis annotations the proxy
+# actually uses; no annotation here resolves the indeterminate base-class types
+# without editing Chart.
+class _ColumnProxy(_SeriesProxy, ColumnChart):  # type: ignore[misc]
     """Column representation over a subset of combo series (side-by-side)."""
 
-    def __init__(self, parent: "ComboChart", indices: list[int], y_axis):
+    def __init__(self, parent: "ComboChart", indices: list[int], y_axis: YAxis) -> None:
         _SeriesProxy.__init__(self, parent, indices, y_axis)
         self.column_gap = getattr(parent, "column_gap", 0.2)
         self.y_stacked = False
@@ -150,7 +161,7 @@ class _ColumnProxy(_SeriesProxy, ColumnChart):
             if self.series_styles and series_idx < len(self.series_styles):
                 style = self.series_styles[series_idx] or {}
                 if style.get("fill"):
-                    fill = style["fill"]
+                    fill = cast("str", style["fill"])
 
             paths = []
             for x_idx, y in enumerate(y_values_series):
@@ -195,7 +206,7 @@ class ComboChart(Chart):
 
     def __init__(
         self,
-        series: list[dict],
+        series: list[dict[str, Any]],
         labels: Labels | None = None,
         width: float = DEFAULT_CHART_WIDTH,
         height: float = DEFAULT_CHART_HEIGHT,
@@ -213,7 +224,7 @@ class ComboChart(Chart):
         if not series or len(series) < 2:
             raise ValueError("ComboChart requires at least two series.")
 
-        normalized = []
+        normalized: list[dict[str, Any]] = []
         for s in series:
             stype = s.get("type", "line")
             if stype not in _VALID_TYPES:
@@ -248,8 +259,9 @@ class ComboChart(Chart):
             self._primary_indices = list(self._secondary_indices)
             self._secondary_indices = []
 
-        names = [s["name"] for s in self.series]
-        if all(n is None for n in names):
+        series_names_list = [s["name"] for s in self.series]
+        names: list[Any] | None = series_names_list
+        if all(n is None for n in series_names_list):
             names = None
 
         super().__init__(
@@ -287,7 +299,7 @@ class ComboChart(Chart):
         if cached is None:
             secondary_data = [self.series[i]["data"] for i in self._secondary_indices]
             cached = YAxis(
-                parent=self,
+                parent=cast("_AxisParent", self),
                 data=secondary_data,
                 labels=None,
                 stacked=False,
@@ -343,8 +355,10 @@ class ComboChart(Chart):
 
         # Lines/areas reuse the line renderer over their subset.
         if line_indices:
-            proxy = _SeriesProxy(self, line_indices, self._axis_for(line_indices[0]))
-            renderer = LineRenderer(proxy)
+            line_proxy = _SeriesProxy(
+                self, line_indices, self._axis_for(line_indices[0])
+            )
+            renderer = LineRenderer(cast("_LineHost", line_proxy))
             g.add_child(renderer.render())
 
         # Secondary y-axis tick labels, rendered into the normal element tree so
@@ -356,7 +370,7 @@ class ComboChart(Chart):
 
     def _render_secondary_axis(self) -> G:
         """Render secondary y-axis tick labels anchored on the right side."""
-        axis = self.secondary_y_axis
+        axis = cast("YAxis", self.secondary_y_axis)
         right_x = self.left_padding + self.plot_width
         group = G(
             font_size=DEFAULT_FONT_SIZE,
@@ -379,7 +393,7 @@ class ComboChart(Chart):
             )
         return group
 
-    def describe(self) -> dict:
+    def describe(self) -> dict[str, Any]:
         meta = super().describe()
         meta["chart_type"] = "ComboChart"
         meta["series_count"] = len(self.series)
@@ -402,7 +416,7 @@ class ComboChart(Chart):
         meta["series"] = series_info
         return meta
 
-    def to_config(self) -> dict:
+    def to_config(self) -> dict[str, Any]:
         cfg = super().to_config()
         cfg["chart_type"] = "ComboChart"
         cfg["series"] = [dict(s) for s in self.series]

--- a/charted/charts/gantt.py
+++ b/charted/charts/gantt.py
@@ -9,16 +9,23 @@ task-duration labels.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date, datetime
+from typing import cast
 
 from charted.charts.chart import Chart
+from charted.charts.scales import TimeValue
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path, Text
 from charted.themes.core import Theme
-from charted.utils.types import Labels, SeriesStyleConfig
+from charted.utils.types import Labels, SeriesStyleConfig, Vector2D
+
+GanttTask = tuple[TimeValue, TimeValue]
+GanttSeries = list[GanttTask]
+DurationFormatter = Callable[[TimeValue, TimeValue], object]
 
 
-def _is_time_value(value) -> bool:
+def _is_time_value(value: object) -> bool:
     """True if a start/end value should be plotted on a date/time axis."""
     return isinstance(value, (date, datetime, str))
 
@@ -74,8 +81,8 @@ class GanttChart(Chart):
 
     def __init__(
         self,
-        data: list,
-        labels: Labels = None,
+        data: list[GanttTask] | list[GanttSeries],
+        labels: Labels | None = None,
         width: float = DEFAULT_CHART_WIDTH,
         height: float = DEFAULT_CHART_HEIGHT,
         title: str | None = None,
@@ -85,9 +92,9 @@ class GanttChart(Chart):
         dependencies: list[tuple[int, int]] | None = None,
         bar_height_ratio: float = 0.6,
         show_today_line: bool = False,
-        x_position=None,
+        x_position: TimeValue | None = None,
         show_durations: bool = False,
-        duration_formatter=None,
+        duration_formatter: DurationFormatter | None = None,
     ):
         if not data:
             raise ValueError("No data was provided to the GanttChart element.")
@@ -147,7 +154,9 @@ class GanttChart(Chart):
             else:
                 labels = [f"Task {i + 1}" for i in range(self._total_tasks)]
 
-        x_data = [all_starts + all_ends]
+        # Time/date values flow through the Chart x_data plumbing unchanged when
+        # a time scale is active; the static type is widened only for mypy.
+        x_data = cast(Vector2D, [all_starts + all_ends])
         y_data = [[float(i) for i in range(self._total_tasks)]]
 
         super().__init__(
@@ -212,14 +221,14 @@ class GanttChart(Chart):
             if self.series_styles and series_idx < len(self.series_styles):
                 style = self.series_styles[series_idx] or {}
                 if style.get("fill"):
-                    fill = style["fill"]
+                    fill = cast(str, style["fill"])
 
             paths = []
             for task_idx, (start, end) in enumerate(series):
                 flat_idx = series_offset_y + task_idx
                 y = flat_idx * self.row_height + self.bar_y_offset
-                x_start = self.x_axis.reproject(start)
-                x_end = self.x_axis.reproject(end)
+                x_start = self.x_axis.reproject(cast(float, start))
+                x_end = self.x_axis.reproject(cast(float, end))
                 width = abs(x_end - x_start)
                 paths.append(Path.get_path(x_start, y, width, self.bar_height))
 
@@ -292,7 +301,7 @@ class GanttChart(Chart):
             result.add_children(line_g, head_g)
 
         if self.show_today_line and self._x_position is not None:
-            x_pos = self.x_axis.reproject(self._x_position)
+            x_pos = self.x_axis.reproject(cast(float, self._x_position))
             line_g = G(
                 stroke=self.theme.grid_color,
                 stroke_dasharray="4,4",
@@ -337,7 +346,7 @@ class GanttChart(Chart):
         offset = 0
         for series in self._raw_data:
             if flat_idx < offset + len(series):
-                return series[flat_idx - offset][0]
+                return cast(float, series[flat_idx - offset][0])
             offset += len(series)
         return 0.0
 
@@ -345,7 +354,7 @@ class GanttChart(Chart):
         offset = 0
         for series in self._raw_data:
             if flat_idx < offset + len(series):
-                return series[flat_idx - offset][1]
+                return cast(float, series[flat_idx - offset][1])
             offset += len(series)
         return 0.0
 
@@ -372,7 +381,7 @@ class GanttChart(Chart):
             return color
         return get_contrast_color(background)
 
-    def _duration_label(self, start, end) -> str:
+    def _duration_label(self, start: TimeValue, end: TimeValue) -> str:
         """Render a task's duration as text.
 
         A caller-supplied ``duration_formatter`` wins. Otherwise date tasks are
@@ -385,7 +394,7 @@ class GanttChart(Chart):
 
             days = (_to_epoch(end) - _to_epoch(start)) / 86400.0
             return f"{round(days)}d"
-        span = end - start
+        span = cast(float, end) - cast(float, start)
         if isinstance(span, float) and span.is_integer():
             span = int(span)
         return str(span)

--- a/charted/charts/heatmap.py
+++ b/charted/charts/heatmap.py
@@ -81,8 +81,8 @@ class HeatmapChart(Chart):
     def __init__(
         self,
         data: list[list[float]],
-        x_labels: Labels = None,
-        y_labels: Labels = None,
+        x_labels: Labels | None = None,
+        y_labels: Labels | None = None,
         width: float = DEFAULT_CHART_WIDTH,
         height: float = DEFAULT_CHART_HEIGHT,
         title: str | None = None,
@@ -215,7 +215,8 @@ class HeatmapChart(Chart):
         """
         labels = [
             format(
-                self._data_min + (self._data_max - self._data_min) * (i / (self.colorbar_ticks - 1)),
+                self._data_min
+                + (self._data_max - self._data_min) * (i / (self.colorbar_ticks - 1)),
                 self.value_format,
             )
             for i in range(self.colorbar_ticks)

--- a/charted/charts/histogram.py
+++ b/charted/charts/histogram.py
@@ -6,6 +6,7 @@ Shows the frequency of values within evenly-spaced intervals.
 from __future__ import annotations
 
 import math
+from typing import Any
 
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
@@ -75,9 +76,9 @@ class Histogram(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        reference_lines: list[dict] | None = None,
+        reference_lines: list[dict[str, Any]] | None = None,
         colors: list[str] | None = None,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, Any] | None = None,
         domain_padding: float | None = None,
     ):
         n_bins = bins if bins is not None else _auto_bins(data)

--- a/charted/charts/line.py
+++ b/charted/charts/line.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, cast
+
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Text
 from charted.themes.core import Theme
 from charted.utils.curves import VALID_CURVES
 from charted.utils.line_renderer import LineRenderer
-from charted.utils.series_style import SeriesStyleConfig
-from charted.utils.types import Labels, Vector, Vector2D
+from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+
+if TYPE_CHECKING:
+    from charted.utils.line_renderer import _LineHost
 
 
 class LineChart(Chart):
@@ -89,11 +93,11 @@ class LineChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list | None = None,
+        annotations: list[Any] | None = None,
         curve: str = "linear",
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict] | None = None,
+        reference_lines: list[dict[str, Any]] | None = None,
         colors: list[str] | None = None,
         legend: str = "none",
         dash_cycle: list[str] | bool | None = None,
@@ -147,7 +151,7 @@ class LineChart(Chart):
         ``stroke_dasharray`` of its own. Returns None when dash cycling is off
         or the cycle slot is the solid (``"none"``) token.
         """
-        cycle = getattr(self, "_dash_cycle", None)
+        cycle = cast("list[str] | None", getattr(self, "_dash_cycle", None))
         if not cycle:
             return None
         dash = cycle[series_idx % len(cycle)]
@@ -158,7 +162,7 @@ class LineChart(Chart):
     @property
     def representation(self) -> G:
         """Generate line chart SVG elements using LineRenderer."""
-        renderer = LineRenderer(self)
+        renderer = LineRenderer(cast("_LineHost", self))
         g = renderer.render()
 
         # Render data labels using the same x positions as the line renderer

--- a/charted/charts/pie.py
+++ b/charted/charts/pie.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from typing import TypedDict, cast
 
 from charted.charts.chart import Chart
 from charted.config import get_pie_label_font_size
@@ -10,7 +11,24 @@ from charted.themes.core import Theme
 from charted.utils.colors import complementary_color, get_contrast_color
 from charted.utils.defaults import DEFAULT_COLORS
 from charted.utils.rendering import create_pie_legend
-from charted.utils.types import Labels, SeriesStyleConfig, Vector
+from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+
+
+class _PieSlice(TypedDict):
+    """Per-slice geometry computed in the pie chart's first render pass."""
+
+    i: int
+    value: float
+    angle: float
+    start_angle: float
+    end_angle: float
+    mid_angle: float
+    mid_rad: float
+    label_display: str
+    text_width_est: float
+    fits_inside: bool
+    inside_label_r: float
+    slice_pct: float
 
 
 class PieChart(Chart):
@@ -47,7 +65,7 @@ class PieChart(Chart):
     def __init__(
         self,
         data: Vector,
-        labels: Labels = None,
+        labels: Labels | None = None,
         width: float = PIE_CHART_WIDTH,
         height: float = PIE_CHART_HEIGHT,
         title: str | None = None,
@@ -57,7 +75,7 @@ class PieChart(Chart):
         start_angle: float = 0,
         series_styles: list[SeriesStyleConfig] | None = None,
         show_percentages: bool = False,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
         legend: str = "none",
         category_patterns: list[str] | bool | None = None,
     ):
@@ -111,8 +129,8 @@ class PieChart(Chart):
         self._generate_colors_from_data(data, base=resolved_theme.colors)
 
         # Create synthetic x_data and y_data for Chart base class compatibility
-        x_data = [[i for i in range(len(data))]]
-        y_data = [[0, 1]]  # Minimal y range
+        x_data = cast(Vector2D, [[i for i in range(len(data))]])
+        y_data = cast(Vector2D, [[0, 1]])  # Minimal y range
 
         super().__init__(
             width=width,
@@ -324,7 +342,7 @@ class PieChart(Chart):
         current_angle = self.start_angle
 
         # --- First pass: compute slice geometry and classify labels ---
-        slices = []  # list of dicts with geometry for each slice
+        slices: list[_PieSlice] = []  # geometry for each slice
         for i, (value, label) in enumerate(zip(data, labels)):
             angle = (value / total) * 360
             start_angle = current_angle
@@ -421,9 +439,9 @@ class PieChart(Chart):
             if self.series_styles and i < len(self.series_styles):
                 style = self.series_styles[i] or {}
                 if style.get("fill"):
-                    slice_color = style["fill"]
+                    slice_color = cast(str, style["fill"])
                 if style.get("fill_opacity"):
-                    slice_opacity = style["fill_opacity"]
+                    slice_opacity = cast(float, style["fill_opacity"])
 
             # Pattern fill (only when the colour wasn't overridden) and the
             # high-contrast wedge outline. Both are no-ops by default.
@@ -435,6 +453,7 @@ class PieChart(Chart):
             outline = self._filled_outline_attrs()
 
             # Render slice path
+            path_data: str | list[str]
             if angle >= 359.9:
                 path_data = self._get_full_circle_path(cx, cy, radius)
                 slice_path = Path(
@@ -503,7 +522,7 @@ class PieChart(Chart):
     def _render_outside_labels(
         self,
         result: G,
-        outside: list,
+        outside: list[_PieSlice],
         cx: float,
         cy: float,
         radius: float,

--- a/charted/charts/polar_area.py
+++ b/charted/charts/polar_area.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from typing import Any, cast
 
 from charted.charts.pie import PieChart
 from charted.config import get_pie_label_font_size
@@ -47,7 +48,7 @@ class PolarAreaChart(PieChart):
     def __init__(
         self,
         data: Vector,
-        labels: Labels = None,
+        labels: Labels | None = None,
         width: float = DEFAULT_CHART_WIDTH,
         height: float = DEFAULT_CHART_HEIGHT,
         title: str | None = None,
@@ -128,7 +129,7 @@ class PolarAreaChart(PieChart):
             nice = 1 if frac < 1.5 else 2 if frac < 3 else 5 if frac < 7 else 10
         else:
             nice = 1 if frac <= 1 else 2 if frac <= 2 else 5 if frac <= 5 else 10
-        return nice * 10**exp
+        return cast("float", nice * 10**exp)
 
     def _radial_scale(self) -> tuple[float, list[float]]:
         """Return (axis_max, tick_values) snapped to round numbers.
@@ -187,9 +188,9 @@ class PolarAreaChart(PieChart):
             if self.series_styles and i < len(self.series_styles):
                 style = self.series_styles[i] or {}
                 if style.get("fill"):
-                    slice_color = style["fill"]
+                    slice_color = cast("str", style["fill"])
                 if style.get("fill_opacity"):
-                    slice_opacity = style["fill_opacity"]
+                    slice_opacity = cast("float", style["fill_opacity"])
 
             draw_fill = (
                 self._category_fill(i, slice_color)
@@ -201,6 +202,7 @@ class PolarAreaChart(PieChart):
             # Full-circle edge case (N == 1): the slice spans the whole circle,
             # so angle_span % 360 == 0 collapses _get_slice_path to a zero-area
             # sliver. Use the full-circle path instead, matching PieChart.
+            path_data: str | list[str]
             if (end_angle - start_angle) >= 359.9:
                 path_data = self._get_full_circle_path(cx, cy, radius)
             else:
@@ -255,8 +257,8 @@ class PolarAreaChart(PieChart):
         theme = self.theme
         resolved = getattr(theme, "resolved_grid_color", None)
         if resolved:
-            return resolved
-        return getattr(theme, "grid_color", "#cccccc")
+            return cast("str", resolved)
+        return cast("str", getattr(theme, "grid_color", "#cccccc"))
 
     def _ring_label_color(self) -> str:
         """High-contrast colour for the numeric ring labels.
@@ -268,8 +270,8 @@ class PolarAreaChart(PieChart):
         theme = self.theme
         resolved = getattr(theme, "resolved_label_color", None)
         if resolved:
-            return resolved
-        return getattr(theme, "title_color", "#333")
+            return cast("str", resolved)
+        return cast("str", getattr(theme, "title_color", "#333"))
 
     def _render_radial_grid(
         self, result: G, cx: float, cy: float, data: list[float]
@@ -369,7 +371,7 @@ class PolarAreaChart(PieChart):
                 )
             )
 
-    def to_config(self) -> dict:
+    def to_config(self) -> dict[str, Any]:
         cfg = super().to_config()
         cfg["data"] = list(self._pie_data)
         cfg["labels"] = [

--- a/charted/charts/radar.py
+++ b/charted/charts/radar.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 from charted.charts.chart import Chart
 from charted.constants import (
     DEFAULT_CHART_HEIGHT,
@@ -10,6 +12,9 @@ from charted.themes.core import Theme
 from charted.utils.defaults import DEFAULT_COLORS
 from charted.utils.radar_renderer import RadarRenderer
 from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+
+if TYPE_CHECKING:
+    from charted.utils.radar_renderer import _RadarHost
 
 
 class RadarChart(Chart):
@@ -127,7 +132,7 @@ class RadarChart(Chart):
         self.show_radial_labels = show_radial_labels
 
         # Create synthetic x_data and y_data for Chart base class compatibility
-        x_data = [[i for i in range(axis_count)] for _ in data]
+        x_data = cast("Vector2D", [[i for i in range(axis_count)] for _ in data])
         y_data = data
         self._series_data = (
             data  # Must set before super().__init__ calls representation
@@ -186,12 +191,12 @@ class RadarChart(Chart):
             palette = list(DEFAULT_COLORS)
         self._colors = [palette[i % len(palette)] for i in range(n_series)]
 
-    def get_base_transform(self) -> list:
+    def get_base_transform(self) -> list[str]:
         """Radar charts use polar coordinates: no base transform needed."""
         return []
 
     @property
     def representation(self) -> G:
         """Generate radar chart SVG elements using RadarRenderer."""
-        renderer = RadarRenderer(self)
+        renderer = RadarRenderer(cast("_RadarHost", self))
         return renderer.render()

--- a/charted/charts/scales.py
+++ b/charted/charts/scales.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 import calendar
 import math
 from datetime import date, datetime, timezone
+from typing import TypeAlias, Union, cast
+
+TimeValue: TypeAlias = Union[date, datetime, str, int, float]
 
 
 class Scale:
@@ -31,7 +34,7 @@ class Scale:
         self.max_value = max_value
 
     @staticmethod
-    def _degenerate_ticks(value: float) -> list:
+    def _degenerate_ticks(value: float) -> list[float]:
         """Return two distinct ticks for a zero-width (min == max) domain.
 
         A single data point, an all-equal series, or all-zero data collapses
@@ -52,7 +55,7 @@ class Scale:
         """Map a pixel offset back to a data value (inverse of reproject)."""
         raise NotImplementedError
 
-    def ticks(self) -> list:
+    def ticks(self) -> list[float]:
         """Return tick positions in data space for this scale."""
         raise NotImplementedError
 
@@ -82,7 +85,7 @@ class LinearScale(Scale):
         value_range = self.max_value - self.min_value
         return self.min_value + (pixel / length) * value_range
 
-    def ticks(self) -> list:
+    def ticks(self) -> list[float]:
         if self.max_value == self.min_value:
             return self._degenerate_ticks(self.min_value)
         return [self.min_value, self.max_value]
@@ -124,7 +127,7 @@ class LogScale(Scale):
         log_val = self._log_min + (pixel / length) * log_range
         return 10**log_val
 
-    def ticks(self) -> list:
+    def ticks(self) -> list[float]:
         """Return the powers of ten spanning the domain (inclusive)."""
         if self.max_value == self.min_value:
             # Single positive point / all-equal positive series: pad to the
@@ -136,7 +139,7 @@ class LogScale(Scale):
             return [int(lo) if lo >= 1 else lo, int(hi) if hi >= 1 else hi]
         lo = math.floor(self._log_min)
         hi = math.ceil(self._log_max)
-        powers = []
+        powers: list[float] = []
         for exp in range(lo, hi + 1):
             value = 10**exp
             if value < self.min_value or value > self.max_value:
@@ -148,7 +151,7 @@ class LogScale(Scale):
         return powers
 
 
-def _to_epoch(value) -> float:
+def _to_epoch(value: TimeValue) -> float:
     """Normalise a date/datetime/ISO-string into epoch seconds.
 
     All conversion is timezone-independent. A timezone-aware ``datetime``
@@ -188,7 +191,7 @@ class TimeScale(Scale):
     the domain bounds and for values passed to :meth:`reproject`.
     """
 
-    def __init__(self, min_value, max_value):
+    def __init__(self, min_value: TimeValue, max_value: TimeValue):
         lo = _to_epoch(min_value)
         hi = _to_epoch(max_value)
         super().__init__(lo, hi)
@@ -197,7 +200,7 @@ class TimeScale(Scale):
     def name(self) -> str:
         return "time"
 
-    def reproject(self, value, length: float) -> float:
+    def reproject(self, value: TimeValue, length: float) -> float:
         epoch = _to_epoch(value)
         value_range = self.max_value - self.min_value
         if value_range == 0:
@@ -219,7 +222,7 @@ class TimeScale(Scale):
     def _span_days(self) -> float:
         return (self.max_value - self.min_value) / 86400.0
 
-    def ticks(self) -> list:
+    def ticks(self) -> list[float]:
         """Return tick positions (epoch seconds) on clean calendar boundaries.
 
         Spans up to ~3 years land on month or quarter boundaries; longer spans
@@ -241,7 +244,7 @@ class TimeScale(Scale):
         if span_days <= 3 * 366:
             # Monthly (or quarterly for ~1-3 year spans) boundaries.
             step_months = 1 if span_days <= 200 else 3
-            ticks = []
+            ticks: list[float] = []
             year, month = start.year, start.month
             # Snap up to the first month boundary >= start.
             if start.day != 1 or start.hour or start.minute or start.second:
@@ -284,13 +287,13 @@ class TimeScale(Scale):
             return ticks
         return self._even_ticks(5)
 
-    def _even_ticks(self, count: int) -> list:
+    def _even_ticks(self, count: int) -> list[float]:
         if count < 2:
             return [self.min_value, self.max_value]
         step = (self.max_value - self.min_value) / (count - 1)
         return [self.min_value + i * step for i in range(count)]
 
-    def tick_labels(self, fmt: str | None = None) -> list:
+    def tick_labels(self, fmt: str | None = None) -> list[str]:
         """Return formatted date strings for each tick position."""
         ticks = self.ticks()
         span_days = self._span_days()
@@ -304,7 +307,9 @@ class TimeScale(Scale):
         return [datetime.fromtimestamp(t, tz=timezone.utc).strftime(fmt) for t in ticks]
 
 
-def make_scale(spec, min_value, max_value) -> Scale:
+def make_scale(
+    spec: str | Scale | None, min_value: TimeValue, max_value: TimeValue
+) -> Scale:
     """Build a Scale from a string spec or pass through a Scale instance.
 
     Args:
@@ -318,9 +323,9 @@ def make_scale(spec, min_value, max_value) -> Scale:
     if isinstance(spec, Scale):
         return spec
     if spec is None or spec == "linear":
-        return LinearScale(min_value, max_value)
+        return LinearScale(cast(float, min_value), cast(float, max_value))
     if spec == "log":
-        return LogScale(min_value, max_value)
+        return LogScale(cast(float, min_value), cast(float, max_value))
     if spec == "time":
         return TimeScale(min_value, max_value)
     raise ValueError(

--- a/charted/charts/scatter.py
+++ b/charted/charts/scatter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from typing import TypedDict, cast
 
 from charted.charts.chart import Chart
 from charted.constants import (
@@ -9,7 +10,7 @@ from charted.constants import (
     QUADRANT_BOTTOM_MARGIN_FACTOR,
     QUADRANT_LABEL_LINE_GAP,
 )
-from charted.html.element import Circle, G, Path, Rect, Text
+from charted.html.element import Circle, Element, G, Path, Rect, Text
 from charted.themes.core import Theme
 from charted.utils.types import (
     PointStyleConfig,
@@ -17,6 +18,19 @@ from charted.utils.types import (
     Vector,
     Vector2D,
 )
+
+
+class _PlacedLabel(TypedDict):
+    """A data label's placement state during collision avoidance."""
+
+    text: str
+    px: float
+    py: float
+    cx: float
+    cy: float
+    w: float
+    h: float
+    marker: float
 
 
 class ScatterChart(Chart):
@@ -134,7 +148,7 @@ class ScatterChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list | None = None,
+        annotations: list[object] | None = None,
         quadrant_labels: list[str] | None = None,
         quadrant_label_inset: float = 12.0,
         quadrant_label_backplate: bool = False,
@@ -142,13 +156,13 @@ class ScatterChart(Chart):
         legend: str = "none",
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict] | None = None,
+        reference_lines: list[dict[str, object]] | None = None,
         colors: list[str] | None = None,
         x_range: tuple[float, float] | None = None,
         y_range: tuple[float, float] | None = None,
         domain_padding: float | None = None,
         avoid_label_collisions: bool = False,
-        value_labels: bool | str | dict | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
     ):
         self._avoid_label_collisions = avoid_label_collisions
         self._point_styles = point_styles
@@ -216,7 +230,7 @@ class ScatterChart(Chart):
         if self.series_styles and series_idx < len(self.series_styles):
             style = self.series_styles[series_idx] or {}
             if style.get("marker_shape"):
-                shape = style["marker_shape"]
+                shape = cast(str, style["marker_shape"])
         return shape
 
     @property
@@ -234,7 +248,7 @@ class ScatterChart(Chart):
             # Default marker size is 4px. A theme that explicitly sets
             # marker_size (e.g. high-contrast) raises it for legibility while
             # the standard themes keep the historical 4px.
-            marker_size = 4
+            marker_size: float = 4
             if self.theme._is_explicit("marker_size"):
                 marker_size = self.theme.marker_size
             # Default shape is a circle; with shape_cycle enabled, each series
@@ -246,11 +260,11 @@ class ScatterChart(Chart):
             if self.series_styles and series_idx < len(self.series_styles):
                 style = self.series_styles[series_idx] or {}
                 if style.get("fill"):
-                    fill = style["fill"]
+                    fill = cast(str, style["fill"])
                 if style.get("marker_size"):
-                    marker_size = style["marker_size"]
+                    marker_size = cast(float, style["marker_size"])
                 if style.get("marker_shape"):
-                    marker_shape = style["marker_shape"]
+                    marker_shape = cast(str, style["marker_shape"])
 
             series = G(fill=fill)
             x_offset = self.x_offset
@@ -265,15 +279,15 @@ class ScatterChart(Chart):
                 p_shape = marker_shape
                 p_size = marker_size
                 p_fill = fill
-                p_opacity = None
+                p_opacity: float | None = None
                 pstyle = self._point_style(series_idx, i)
                 if pstyle:
                     if pstyle.get("marker_shape"):
-                        p_shape = pstyle["marker_shape"]
+                        p_shape = cast(str, pstyle["marker_shape"])
                     if pstyle.get("marker_size"):
-                        p_size = pstyle["marker_size"]
+                        p_size = cast(float, pstyle["marker_size"])
                     if pstyle.get("fill"):
-                        p_fill = pstyle["fill"]
+                        p_fill = cast(str, pstyle["fill"])
                     if pstyle.get("opacity") is not None:
                         p_opacity = pstyle["opacity"]
                 mark = self._marker_element(p_shape, x, y, p_size, p_fill)
@@ -284,7 +298,7 @@ class ScatterChart(Chart):
                     if p_fill != fill:
                         mark.kwargs["fill"] = p_fill
                     if p_opacity is not None:
-                        mark.kwargs["opacity"] = p_opacity
+                        mark.kwargs["opacity"] = cast(str, p_opacity)
                     if title is not None:
                         mark.add_child(title)
                     series.add_child(mark)
@@ -313,7 +327,7 @@ class ScatterChart(Chart):
 
         return wrapper
 
-    def _point_style(self, series_idx: int, point_idx: int):
+    def _point_style(self, series_idx: int, point_idx: int) -> PointStyleConfig | None:
         """Return the ``PointStyleConfig`` for one point, or None.
 
         ``point_styles`` is a list of per-series rows mirroring the data shape;
@@ -327,7 +341,9 @@ class ScatterChart(Chart):
             return None
         return row[point_idx] or None
 
-    def _marker_element(self, shape: str, x: float, y: float, size: float, fill: str):
+    def _marker_element(
+        self, shape: str, x: float, y: float, size: float, fill: str
+    ) -> Element | None:
         """Build a marker element centred at (x, y).
 
         ``size`` is the radius / half-extent, so every shape shares the same
@@ -415,7 +431,7 @@ class ScatterChart(Chart):
         line_color = self.theme.resolved_reference_line_color
 
         # Gather placed labels and their anchor markers in plot coordinates.
-        placed: list[dict] = []
+        placed: list[_PlacedLabel] = []
         for series_idx, label_row in enumerate(labels):
             if series_idx >= len(self.y_values):
                 break
@@ -426,7 +442,7 @@ class ScatterChart(Chart):
             if self.series_styles and series_idx < len(self.series_styles):
                 style = self.series_styles[series_idx] or {}
                 if style.get("marker_size"):
-                    marker_size = float(style["marker_size"])
+                    marker_size = float(cast(float, style["marker_size"]))
             for i, label_text in enumerate(label_row):
                 if i >= len(x_vals) or not label_text:
                     continue
@@ -491,7 +507,7 @@ class ScatterChart(Chart):
         return g
 
     @staticmethod
-    def _deoverlap_labels(placed: list[dict], iterations: int = 60) -> None:
+    def _deoverlap_labels(placed: list[_PlacedLabel], iterations: int = 60) -> None:
         """Greedily push overlapping label boxes apart, in place.
 
         Each iteration walks every label pair plus every label/marker pair and,
@@ -501,7 +517,17 @@ class ScatterChart(Chart):
         heuristic with no global guarantee (see ``_render_data_labels``).
         """
 
-        def overlap(a_cx, a_cy, a_w, a_h, b_cx, b_cy, b_w, b_h, pad=2.0):
+        def overlap(
+            a_cx: float,
+            a_cy: float,
+            a_w: float,
+            a_h: float,
+            b_cx: float,
+            b_cy: float,
+            b_w: float,
+            b_h: float,
+            pad: float = 2.0,
+        ) -> tuple[float, float] | None:
             ox = (a_w + b_w) / 2 + pad - abs(a_cx - b_cx)
             oy = (a_h + b_h) / 2 + pad - abs(a_cy - b_cy)
             if ox > 0 and oy > 0:
@@ -514,8 +540,14 @@ class ScatterChart(Chart):
                 # Label vs every other label.
                 for b in placed[i + 1 :]:
                     res = overlap(
-                        a["cx"], a["cy"], a["w"], a["h"],
-                        b["cx"], b["cy"], b["w"], b["h"],
+                        a["cx"],
+                        a["cy"],
+                        a["w"],
+                        a["h"],
+                        b["cx"],
+                        b["cy"],
+                        b["w"],
+                        b["h"],
                     )
                     if res is None:
                         continue
@@ -535,8 +567,14 @@ class ScatterChart(Chart):
                 for b in placed:
                     m = b["marker"] * 2
                     res = overlap(
-                        a["cx"], a["cy"], a["w"], a["h"],
-                        b["px"], b["py"], m, m,
+                        a["cx"],
+                        a["cy"],
+                        a["w"],
+                        a["h"],
+                        b["px"],
+                        b["py"],
+                        m,
+                        m,
                     )
                     if res is None:
                         continue

--- a/charted/cli/batch.py
+++ b/charted/cli/batch.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from .create import CHART_TYPES, load_data
 
 
-def batch_command(args: argparse.Namespace):
+def batch_command(args: argparse.Namespace) -> None:
     """Generate multiple charts from a directory."""
     input_dir = Path(args.input_dir)
     output_dir = Path(args.output_dir)
@@ -101,7 +101,18 @@ def batch_command(args: argparse.Namespace):
 def _infer_chart_type(filename: str) -> str:
     """Infer chart type from filename."""
     # Look for chart type keywords in filename
-    keywords = ["bar", "column", "line", "pie", "scatter", "area", "boxplot", "histogram", "heatmap", "gantt"]
+    keywords = [
+        "bar",
+        "column",
+        "line",
+        "pie",
+        "scatter",
+        "area",
+        "boxplot",
+        "histogram",
+        "heatmap",
+        "gantt",
+    ]
 
     for keyword in keywords:
         if keyword in filename:

--- a/charted/cli/create.py
+++ b/charted/cli/create.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 from ..charts import (
     AreaChart,
@@ -40,7 +41,7 @@ CHART_TYPES = {
 }
 
 
-def load_data(data_path: str, transpose: bool = False) -> dict:
+def load_data(data_path: str, transpose: bool = False) -> dict[str, Any]:
     """Load data from CSV or JSON file.
 
     Args:
@@ -60,14 +61,14 @@ def load_data(data_path: str, transpose: bool = False) -> dict:
 
     if suffix == ".json":
         with open(path) as f:
-            return json.load(f)
+            return cast("dict[str, Any]", json.load(f))
     elif suffix == ".csv":
         return _parse_csv(path, transpose=transpose)
     else:
         raise ValueError(f"Unsupported file format: {suffix}. Use .csv or .json")
 
 
-def _to_number(value: str):
+def _to_number(value: str) -> float | str:
     """Convert a CSV cell to a float, leaving non-numeric text untouched."""
     try:
         return float(value)
@@ -75,7 +76,7 @@ def _to_number(value: str):
         return value
 
 
-def _parse_csv(path: Path, transpose: bool = False) -> dict:
+def _parse_csv(path: Path, transpose: bool = False) -> dict[str, Any]:
     """Parse a CSV file into a chart-compatible data dict.
 
     Default layout (``transpose=False``): the first column is the x-axis
@@ -113,7 +114,7 @@ def _parse_csv(path: Path, transpose: bool = False) -> dict:
         return {"data": data_values, "labels": labels}
 
 
-def _parse_csv_transposed(path: Path) -> dict:
+def _parse_csv_transposed(path: Path) -> dict[str, Any]:
     """Parse a wide / series-per-row CSV (see _parse_csv for the layout)."""
     import csv
 
@@ -135,7 +136,7 @@ def _parse_csv_transposed(path: Path) -> dict:
         series_names.append(row[0])
         data_values.append([_to_number(cell) for cell in row[1:]])
 
-    result: dict = {"labels": labels, "series_names": series_names}
+    result: dict[str, Any] = {"labels": labels, "series_names": series_names}
     if len(data_values) == 1:
         result["data"] = data_values[0]
     else:
@@ -143,7 +144,7 @@ def _parse_csv_transposed(path: Path) -> dict:
     return result
 
 
-def _build_combo_kwargs(data: dict) -> dict:
+def _build_combo_kwargs(data: dict[str, Any]) -> dict[str, Any]:
     """Map loaded data into ComboChart's series-based keyword arguments.
 
     Accepts either a dict that already carries a ``series`` list (passed
@@ -196,7 +197,7 @@ def _build_combo_kwargs(data: dict) -> dict:
     return kwargs
 
 
-def create_command(args: argparse.Namespace):
+def create_command(args: argparse.Namespace) -> None:
     """Create a new chart."""
     chart_type = args.chart_type
     output_path = Path(args.output)

--- a/charted/commands/create_readme_graphs.py
+++ b/charted/commands/create_readme_graphs.py
@@ -1,8 +1,11 @@
 import os
 import random
+from typing import cast
 
 from charted.charts import ColumnChart, LineChart, ScatterChart
+from charted.themes.core import Theme
 from charted.utils.defaults import EXAMPLES_DIR
+from charted.utils.types import Vector, Vector2D
 
 y_data = [
     [50, 100, 150, 200, 250, 300, 150, 200, 350, 225],
@@ -13,7 +16,7 @@ x_data = [-5, 0, 1, 2, 3, 4, 5, 10, 12, 20]
 
 class Examples:
     @property
-    def scatter(self):
+    def scatter(self) -> ScatterChart:
         return ScatterChart(
             title="Example Scatter Graph",
             y_data=[
@@ -27,48 +30,60 @@ class Examples:
         )
 
     @property
-    def column(self):
+    def column(self) -> ColumnChart:
         # Multi-column chart showing sales by product category over quarters
         return ColumnChart(
             title="Product Sales by Quarter ($M)",
-            data=[
-                [45, 52, 48, 61],  # Electronics
-                [32, 38, 45, 52],  # Clothing
-                [28, 35, 42, 48],  # Home & Garden
-                [22, 35, 42, 42],  # Sports
-                [18, 25, 32, 38],  # Books
-            ],
+            data=cast(
+                "Vector2D",
+                [
+                    [45, 52, 48, 61],  # Electronics
+                    [32, 38, 45, 52],  # Clothing
+                    [28, 35, 42, 48],  # Home & Garden
+                    [22, 35, 42, 42],  # Sports
+                    [18, 25, 32, 38],  # Books
+                ],
+            ),
             labels=["Q1", "Q2", "Q3", "Q4"],
             width=700,
             height=500,
-            theme={
-                "padding": {
-                    "v_padding": 0.12,
-                    "h_padding": 0.12,
-                }
-            },
+            theme=cast(
+                "Theme",
+                {
+                    "padding": {
+                        "v_padding": 0.12,
+                        "h_padding": 0.12,
+                    }
+                },
+            ),
         )
 
     @property
-    def line(self):
+    def line(self) -> LineChart:
         return LineChart(
             title="Example Labelled Line Graph",
             data=[5 * (1.5**n) for n in range(0, 11)],
             labels=["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"],
-            theme={
-                "colors": ["#204C9E"],
-            },
+            theme=cast(
+                "Theme",
+                {
+                    "colors": ["#204C9E"],
+                },
+            ),
         )
 
     @property
-    def xy_line(self):
+    def xy_line(self) -> LineChart:
         return LineChart(
             title="Monthly Temperature vs CO2 Concentration",
-            data=[
-                [32, 35, 42, 52, 62, 72, 78, 76, 68, 55, 45, 38],
-                [315, 318, 322, 328, 335, 342, 348, 352, 348, 342, 335, 328],
-            ],
-            x_data=[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
+            data=cast(
+                "Vector2D",
+                [
+                    [32, 35, 42, 52, 62, 72, 78, 76, 68, 55, 45, 38],
+                    [315, 318, 322, 328, 335, 342, 348, 352, 348, 342, 335, 328],
+                ],
+            ),
+            x_data=cast("Vector", [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]),
             labels=[
                 "Jan",
                 "Feb",

--- a/charted/config.py
+++ b/charted/config.py
@@ -2,11 +2,12 @@
 
 import os
 from pathlib import Path
+from typing import Any, cast
 
 try:
-    import tomllib
+    import tomllib  # type: ignore[import-not-found,unused-ignore]
 except ImportError:
-    import tomli as tomllib
+    import tomli as tomllib  # type: ignore[import-not-found]
 
 from .constants import (
     DEFAULT_CHART_HEIGHT,
@@ -40,9 +41,9 @@ def find_config(start_dir: str | None = None) -> Path | None:
     return None
 
 
-def load_config(config_path: str | Path | None = None) -> dict:
+def load_config(config_path: str | Path | None = None) -> dict[str, Any]:
     """Load config from .chartedrc file, returning defaults if not found."""
-    defaults = {
+    defaults: dict[str, Any] = {
         "font": DEFAULT_FONT,
         "font_size": DEFAULT_FONT_SIZE,
         "title_font_size": DEFAULT_TITLE_FONT_SIZE,
@@ -85,7 +86,7 @@ def load_config(config_path: str | Path | None = None) -> dict:
     return defaults
 
 
-def get_chart_theme(config: dict, chart_type: str) -> dict | None:
+def get_chart_theme(config: dict[str, Any], chart_type: str) -> dict[str, Any] | None:
     """Get chart-type-specific theme overrides.
 
     Args:
@@ -96,10 +97,11 @@ def get_chart_theme(config: dict, chart_type: str) -> dict | None:
         Chart-specific theme overrides or None.
     """
     charts_config = config.get("charts", {})
-    return charts_config.get(chart_type, None)
+    result: dict[str, Any] | None = charts_config.get(chart_type, None)
+    return result
 
 
-def get_font(config: dict | None = None) -> Font:
+def get_font(config: dict[str, Any] | None = None) -> Font:
     """Create a Font instance from config.
 
     Args:
@@ -118,7 +120,7 @@ def get_font(config: dict | None = None) -> Font:
     )
 
 
-def get_title_font(config: dict | None = None) -> Font:
+def get_title_font(config: dict[str, Any] | None = None) -> Font:
     """Create a Font instance for titles from config.
 
     Args:
@@ -137,7 +139,7 @@ def get_title_font(config: dict | None = None) -> Font:
     )
 
 
-def get_bar_gap(config: dict | None = None) -> float:
+def get_bar_gap(config: dict[str, Any] | None = None) -> float:
     """Get bar gap setting from config.
 
     Args:
@@ -149,10 +151,10 @@ def get_bar_gap(config: dict | None = None) -> float:
     if config is None:
         config = load_config()
 
-    return config.get("bar", {}).get("bar_gap", 0.50)
+    return cast("float", config.get("bar", {}).get("bar_gap", 0.50))
 
 
-def get_column_gap(config: dict | None = None) -> float:
+def get_column_gap(config: dict[str, Any] | None = None) -> float:
     """Get column gap setting from config.
 
     Args:
@@ -164,10 +166,10 @@ def get_column_gap(config: dict | None = None) -> float:
     if config is None:
         config = load_config()
 
-    return config.get("column", {}).get("column_gap", 0.50)
+    return cast("float", config.get("column", {}).get("column_gap", 0.50))
 
 
-def get_pie_label_font_size(config: dict | None = None) -> int:
+def get_pie_label_font_size(config: dict[str, Any] | None = None) -> int:
     """Get pie label font size from config.
 
     Args:
@@ -179,7 +181,9 @@ def get_pie_label_font_size(config: dict | None = None) -> int:
     if config is None:
         config = load_config()
 
-    return config.get("pie", {}).get("label_font_size", PIE_LABEL_FONT_SIZE)
+    return cast(
+        "int", config.get("pie", {}).get("label_font_size", PIE_LABEL_FONT_SIZE)
+    )
 
 
 def get_font_definitions_dir() -> str:

--- a/charted/fonts/tkinter.py
+++ b/charted/fonts/tkinter.py
@@ -4,6 +4,8 @@ Provides TextMeasurer for measuring text dimensions using tkinter.
 Gracefully handles environments where tkinter is not available.
 """
 
+from typing import Any, cast
+
 try:
     import tkinter as tk
     from tkinter import font as tkfont
@@ -43,7 +45,7 @@ class TextMeasurer:
     ) -> tuple[float, float]:
         if self.root is None:
             raise RuntimeError("TextMeasurer must be used within a 'with' statement")
-        font = tkfont.Font(family=family, size=size, weight=weight)
+        font = tkfont.Font(family=family, size=size, weight=cast("Any", weight))
 
         canvas = tk.Canvas(self.root)
         text_id = canvas.create_text(0, 0, text=text, font=font, anchor="nw")
@@ -52,7 +54,7 @@ class TextMeasurer:
 
         return font.measure(text), height
 
-    def __exit__(self, *args, **kwargs) -> None:
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
         if self.root:
             self.root.destroy()
             self.root = None

--- a/charted/fonts/utils.py
+++ b/charted/fonts/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Any
 
 from charted.utils.defaults import BASE_DEFINITIONS_DIR
 from charted.utils.helpers import nested_defaultdict
@@ -13,7 +14,7 @@ def create_font_definition(
     from charted.fonts.tkinter import TextMeasurer
 
     chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`~!@#$%^&*()-_=+[]{}|;:\'",.<>?/\\"£¥€©®™✓•¶§±æøåßüñ¿¡çµ½¼¾×÷°ƒ∆≈∞Ω≠≤≥¬√πø∆¥¤¢₱₩₹₽℅ℓ№©℗℠℮∞‽ '
-    lookup = nested_defaultdict()
+    lookup: Any = nested_defaultdict()
 
     with TextMeasurer() as tm:
         for font_size in range(min_font_size, max_font_size):

--- a/charted/fonts/wrapper.py
+++ b/charted/fonts/wrapper.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from charted.utils.defaults import BASE_DEFINITIONS_DIR, DEFAULT_FONT, DEFAULT_FONT_SIZE
 
@@ -46,7 +46,7 @@ class Font:
 
         try:
             with open(font_path, "r") as f:
-                return json.load(f)
+                return cast("dict[str, dict[str, Any]]", json.load(f))
         except json.JSONDecodeError as e:
             import warnings
 
@@ -67,7 +67,7 @@ class Font:
 
         try:
             with open(fallback_path, "r") as f:
-                return json.load(f)
+                return cast("dict[str, dict[str, Any]]", json.load(f))
         except (json.JSONDecodeError, IOError):
             return {}
 
@@ -127,7 +127,7 @@ class Font:
         char_code = ord(char)
 
         if str(char_code) in definitions:
-            return definitions[str(char_code)].get("width", 5)
+            return cast("float", definitions[str(char_code)].get("width", 5))
         return 5  # Default width for unknown chars
 
     @classmethod

--- a/charted/html/element.py
+++ b/charted/html/element.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
+from typing import Union, cast
 from xml.sax.saxutils import escape as _xml_escape
 
-Children = list["Element"]
+Child = Union["Element", str]
+Children = list[Child]
 
 
 def _escape_attr(value: str) -> str:
@@ -19,10 +23,10 @@ class Element(object):
     children: Children = []
     class_name: str | None = None
 
-    def __init__(self, parent: object = None, **kwargs):
+    def __init__(self, parent: object = None, **kwargs: object) -> None:
         self.parent = parent
 
-        _kwargs = dict(kwargs)
+        _kwargs: dict[str, object] = dict(kwargs)
         class_name = _kwargs.pop("class_name", None)
         if class_name:
             _kwargs["class"] = class_name
@@ -31,14 +35,14 @@ class Element(object):
             if type(value) is list:
                 _kwargs[key] = " ".join(value)
 
-        self.kwargs: dict[str, str] = {**self.kwargs, **_kwargs}
+        self.kwargs: dict[str, str] = cast("dict[str, str]", {**self.kwargs, **_kwargs})
 
         if self.class_name:
             self.kwargs["class"] = self.class_name
 
-        self.children: list = []
+        self.children: Children = []
 
-    def __new__(cls, *args, **kwargs) -> "Element":
+    def __new__(cls, *args: object, **kwargs: object) -> "Element":
         instance = super().__new__(cls)
         instance.children = []
         return instance
@@ -78,11 +82,13 @@ class Element(object):
             str: A string containing the HTML markup for all child elements.
         """
         return "".join(
-            child.html if type(child) is not str else _xml_escape(child)
+            cast("Element", child).html
+            if type(child) is not str
+            else _xml_escape(child)
             for child in self.children
         )
 
-    def add_child(self, child: "Element") -> "Element":
+    def add_child(self, child: Child | None) -> "Element":
         """Add a child element to the current element.
 
         Args:
@@ -95,7 +101,7 @@ class Element(object):
             self.children.append(child)
         return self
 
-    def add_children(self, *children: Children) -> "Element":
+    def add_children(self, *children: Child | None) -> "Element":
         """Add multiple child elements to the current element.
 
         Args:
@@ -136,7 +142,7 @@ class Path(Element):
     tag = "path"
 
     @classmethod
-    def get_path(cls, x: float, y: float, width: float, height: float) -> list[str]:
+    def get_path(cls, x: float, y: float, width: float, height: float) -> str:
         from charted.utils.helpers import round_coordinate
 
         return " ".join(
@@ -153,7 +159,7 @@ class Path(Element):
 class Text(Element):
     tag = "text"
 
-    def __init__(self, text: str = None, **kwargs):
+    def __init__(self, text: str | None = None, **kwargs: object) -> None:
         super().__init__(**kwargs)
         self.add_child(text)
 
@@ -163,7 +169,7 @@ class TSpan(Element):
 
     tag = "tspan"
 
-    def __init__(self, text: str = None, **kwargs):
+    def __init__(self, text: str | None = None, **kwargs: object) -> None:
         super().__init__(**kwargs)
         self.add_child(text)
 
@@ -178,7 +184,7 @@ class Title(Element):
 
     tag = "title"
 
-    def __init__(self, text: str = None, **kwargs):
+    def __init__(self, text: str | None = None, **kwargs: object) -> None:
         super().__init__(**kwargs)
         self.add_child(text)
 

--- a/charted/themes/core.py
+++ b/charted/themes/core.py
@@ -3,7 +3,7 @@
 import re
 from dataclasses import dataclass, field, replace
 from functools import wraps
-from typing import Optional
+from typing import Any, Optional
 
 from charted.constants import REFERENCE_LINE_WIDTH
 
@@ -366,9 +366,9 @@ class Theme:
     def _is_explicit(self, field_name: str) -> bool:
         """Check if a field was explicitly set (differs from class default)."""
         class_default = self.__class__.__dataclass_fields__[field_name].default
-        return getattr(self, field_name) != class_default
+        return bool(getattr(self, field_name) != class_default)
 
-    def _provided_fields(self) -> frozenset:
+    def _provided_fields(self) -> frozenset[str]:
         """Names of fields explicitly passed to this instance's constructor.
 
         Recorded by the wrapped ``__init__`` (see below). Used by
@@ -702,7 +702,7 @@ def _wrap_theme_init() -> None:
     signature = inspect.signature(original_init)
 
     @wraps(original_init)
-    def __init__(self, *args, **kwargs):  # noqa: N807
+    def __init__(self: Theme, *args: Any, **kwargs: Any) -> None:  # noqa: N807
         # The tracking marker leaks into ``vars(theme)``; tolerate (and honour)
         # it when a caller round-trips a theme via ``Theme(**vars(theme))`` so
         # the provided-set survives the copy and isn't passed to the dataclass
@@ -721,7 +721,7 @@ def _wrap_theme_init() -> None:
         original_init(self, *args, **kwargs)
         object.__setattr__(self, "_explicitly_set", provided)
 
-    Theme.__init__ = __init__
+    Theme.__init__ = __init__  # type: ignore[method-assign]
 
 
 _wrap_theme_init()

--- a/charted/themes/validation.py
+++ b/charted/themes/validation.py
@@ -4,10 +4,11 @@ This module provides functions to validate theme colors and generate
 warnings when contrast ratios don't meet accessibility standards.
 """
 
+from charted.themes.core import Theme
 from charted.utils.color_manager import ColorManager
 
 
-def validate_theme(theme) -> list[str]:
+def validate_theme(theme: Theme) -> list[str]:
     """Validate theme colors for WCAG contrast compliance.
 
     Checks:

--- a/charted/utils/color_manager.py
+++ b/charted/utils/color_manager.py
@@ -4,7 +4,7 @@ This module provides a ColorManager class for automatic color cycling,
 palette expansion, and contrast validation.
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from charted.utils.colors import calculate_contrast_ratio
 
@@ -106,7 +106,7 @@ class ColorManager:
         ratio = calculate_contrast_ratio(foreground, background)
         return ratio
 
-    def validate_theme(self, theme) -> List[str]:
+    def validate_theme(self, theme: Any) -> List[str]:
         """Validate theme colors for WCAG contrast compliance.
 
         Args:

--- a/charted/utils/colors.py
+++ b/charted/utils/colors.py
@@ -1,6 +1,6 @@
 import colorsys
 import re
-from typing import Generator
+from typing import Generator, cast
 
 
 def _hsl_to_rgb(hsl: str) -> tuple[int, int, int]:
@@ -103,7 +103,10 @@ def hex_to_rgb(hex: str) -> tuple[int, int, int]:
             f"Invalid hex color length: expected 3, 6, or 8 characters, got {len(hex)}"
         )
     try:
-        return tuple(int(hex[i : i + 2], 16) for i in (0, 2, 4))
+        return cast(
+            "tuple[int, int, int]",
+            tuple(int(hex[i : i + 2], 16) for i in (0, 2, 4)),
+        )
     except ValueError:
         raise ValueError(f"Invalid hex color: {hex}")
 
@@ -152,7 +155,7 @@ def interpolate_color(a: str, b: str, t: float) -> str:
     )
 
 
-def interpolate_palette(palette_or_list, t: float) -> str:
+def interpolate_palette(palette_or_list: str | list[str], t: float) -> str:
     """Map t in [0, 1] to a color along a multi-stop gradient.
 
     The palette stops are spread evenly across [0, 1]. The value is
@@ -207,8 +210,11 @@ def complementary_color(hex_color: str) -> str:
         b=rgb[2] / 255.0,
     )
     comp_hsv = ((hsv[0] + 0.5) % 1.0, hsv[1], hsv[2])
-    comp_rgb = colorsys.hsv_to_rgb(*comp_hsv)
-    comp_rgb = tuple(int(c * 255) for c in comp_rgb)
+    comp_rgb_float = colorsys.hsv_to_rgb(*comp_hsv)
+    comp_rgb = cast(
+        "tuple[int, int, int]",
+        tuple(int(c * 255) for c in comp_rgb_float),
+    )
     return rgb_to_hex(comp_rgb)
 
 
@@ -252,7 +258,7 @@ def calculate_contrast_ratio(color1: str, color2: str) -> float:
             v = value / 255.0
             if v <= 0.03928:
                 return v / 12.92
-            return ((v + 0.055) / 1.055) ** 2.4
+            return float(((v + 0.055) / 1.055) ** 2.4)
 
         r, g, b = rgb
         return (

--- a/charted/utils/config_schema.py
+++ b/charted/utils/config_schema.py
@@ -139,7 +139,7 @@ def validate_theme_dict(theme_dict: Dict[str, Any]) -> tuple[bool, List[str]]:
                 errors.append(f"{field} must be a string")
 
     # Numeric field validation
-    numeric_fields = {
+    numeric_fields: dict[str, tuple[float, float, float]] = {
         "legend_font_size": (8, 72, 11),
         "title_font_size": (8, 72, 16),
         "h_padding": (0.0, 0.5, 0.05),
@@ -147,7 +147,7 @@ def validate_theme_dict(theme_dict: Dict[str, Any]) -> tuple[bool, List[str]]:
         "marker_size": (1.0, 20.0, 3.0),
     }
 
-    for field, (min_val, max_val, default) in numeric_fields.items():
+    for field, (min_val, max_val, _default) in numeric_fields.items():
         if field in theme_dict:
             value = theme_dict[field]
             if not isinstance(value, (int, float)):

--- a/charted/utils/data_input.py
+++ b/charted/utils/data_input.py
@@ -11,7 +11,9 @@ from typing import Any
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 
 
-def auto_size(data, width: float | None = None, height: float | None = None):
+def auto_size(
+    data: Any, width: float | None = None, height: float | None = None
+) -> tuple[float, float]:
     """Calculate canvas dimensions based on data size.
 
     If width/height are not provided, scale up for datasets larger
@@ -40,6 +42,8 @@ def auto_size(data, width: float | None = None, height: float | None = None):
             n_cols = len(data)
 
         # Scale: 50px per data point, min 500x500
+        w: float
+        h: float
         if width is None:
             w = max(DEFAULT_CHART_WIDTH, n_cols * 50)
         else:
@@ -53,7 +57,7 @@ def auto_size(data, width: float | None = None, height: float | None = None):
     return DEFAULT_CHART_WIDTH, DEFAULT_CHART_HEIGHT
 
 
-def from_dict(data: dict, **kwargs) -> Any:
+def from_dict(data: dict[str, Any], **kwargs: Any) -> Any:
     """Create a chart from a dict-based config.
 
     Expects a dict with at least ``data`` key containing the raw data,
@@ -119,7 +123,7 @@ def from_dict(data: dict, **kwargs) -> Any:
     return chart_cls(**filtered_cfg)
 
 
-def from_dataframe(df, **kwargs) -> Any:
+def from_dataframe(df: Any, **kwargs: Any) -> Any:
     """Create a chart from a pandas DataFrame.
 
     Accepts an optional ``pandas.DataFrame``. If pandas is not installed,
@@ -142,9 +146,9 @@ def from_dataframe(df, **kwargs) -> Any:
 
     # Try pandas import: graceful skip if unavailable
     try:
-        import pandas as pd
+        import pandas as pd  # type: ignore[import-untyped]
     except ImportError:
-        pd = None  # type: ignore
+        pd = None
 
     chart_type = kwargs.pop("chart_type", None)
     cls_map = _CHART_CLASSES()
@@ -217,7 +221,7 @@ def from_dataframe(df, **kwargs) -> Any:
     )
 
 
-def auto(data, **kwargs) -> Any:
+def auto(data: Any, **kwargs: Any) -> Any:
     """Auto-detect chart type from data shape and create the chart.
 
     Heuristic:
@@ -252,6 +256,7 @@ def auto(data, **kwargs) -> Any:
     # maps to marker radius -> BubbleChart.
     if "sizes" in kwargs and kwargs["sizes"] is not None:
         chart_cls = cls_map.get("BubbleChart")
+        assert chart_cls is not None
         if isinstance(data, list) and data and isinstance(data[0], list):
             x, y = data[0], data[1]
         else:
@@ -271,6 +276,7 @@ def auto(data, **kwargs) -> Any:
                 chart_cls = cls_map.get("PieChart")
             else:
                 chart_cls = cls_map.get("BarChart")
+            assert chart_cls is not None
             return chart_cls(data=data, **kwargs)
 
         # 2D data
@@ -280,14 +286,17 @@ def auto(data, **kwargs) -> Any:
         if n_rows <= 3 and n_cols > 3:
             # Few rows, many columns: could be grouped bar or line
             chart_cls = cls_map.get("ColumnChart")
+            assert chart_cls is not None
             return chart_cls(data=data, **kwargs)
         elif n_rows > 3 and n_cols <= 6:
             # Many rows, few columns: line chart
             chart_cls = cls_map.get("LineChart")
+            assert chart_cls is not None
             return chart_cls(data=data, **kwargs)
         else:
             # Square-ish matrix: heatmap
             chart_cls = cls_map.get("HeatmapChart")
+            assert chart_cls is not None
             return chart_cls(data=data, **kwargs)
 
     if isinstance(data, dict):

--- a/charted/utils/data_input.py
+++ b/charted/utils/data_input.py
@@ -88,10 +88,11 @@ def from_dict(data: dict[str, Any], **kwargs: Any) -> Any:
     raw = cfg.pop("data", None)
     cls_map = _CHART_CLASSES()
 
+    chart_cls: Any
     if chart_type and chart_type in cls_map:
         chart_cls = cls_map[chart_type]
     else:
-        chart_cls = cls_map.get("BarChart")
+        chart_cls = cls_map["BarChart"]
 
     # Flatten dict-style data into constructor args
     if isinstance(raw, dict):
@@ -153,10 +154,11 @@ def from_dataframe(df: Any, **kwargs: Any) -> Any:
     chart_type = kwargs.pop("chart_type", None)
     cls_map = _CHART_CLASSES()
 
+    chart_cls: Any
     if chart_type and chart_type in cls_map:
         chart_cls = cls_map[chart_type]
     else:
-        chart_cls = cls_map.get("BarChart")
+        chart_cls = cls_map["BarChart"]
 
     if pd is not None and isinstance(df, pd.DataFrame):
         numeric_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
@@ -244,6 +246,7 @@ def auto(data: Any, **kwargs: Any) -> Any:
     from charted.charts import _CHART_CLASSES
 
     cls_map = _CHART_CLASSES()
+    chart_cls: Any
 
     # Auto-size if width/height not specified
     if "width" not in kwargs and "height" not in kwargs:

--- a/charted/utils/data_model.py
+++ b/charted/utils/data_model.py
@@ -116,7 +116,7 @@ class DataModel:
     # =========================================================================
 
     @classmethod
-    def validate_data(cls, data: Vector | Vector2D | None) -> Vector2D:
+    def validate_data(cls, data: Vector | Vector2D | None) -> Vector2D | None:
         """Validate and normalize chart data.
 
         Args:
@@ -137,7 +137,7 @@ class DataModel:
 
         # Convert single series to 2D
         if not isinstance(data[0], list):
-            data = [data]  # type: ignore
+            data = [data]
 
         max_length = max([len(i) for i in data])
 
@@ -158,7 +158,7 @@ class DataModel:
                         "Infinite values are not allowed in chart data"
                     )
 
-        return data  # type: ignore
+        return data
 
     @classmethod
     def create_default_labels(cls, array_len: int) -> Labels:

--- a/charted/utils/exceptions.py
+++ b/charted/utils/exceptions.py
@@ -14,7 +14,7 @@ class InvalidValue(ChartedError):
         self.value = value
         super().__init__(self.__str__())
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"'{self.value}' is not a valid value for '{self.name}'"
 
 
@@ -35,7 +35,7 @@ class DataShapeError(ChartedError):
         self.detail = detail
         super().__init__(self.__str__())
 
-    def __str__(self):
+    def __str__(self) -> str:
         msg = f"Data shape mismatch: expected {self.expected} but got {self.actual}. "
         if self.detail:
             msg += self.detail
@@ -54,7 +54,7 @@ class LabelMismatchError(ChartedError):
         self.axis = axis
         super().__init__(self.__str__())
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"Label count mismatch: {self.n_labels} {self.axis}-labels "
             f"provided but data has {self.n_data} values. "

--- a/charted/utils/helpers.py
+++ b/charted/utils/helpers.py
@@ -1,6 +1,7 @@
 import functools
 import math
 from collections import defaultdict
+from typing import cast
 
 from charted.fonts.wrapper import Font
 from charted.utils.defaults import DEFAULT_FONT, DEFAULT_FONT_SIZE
@@ -130,12 +131,14 @@ def common_denominators(a: float, b: float) -> Vector:
 
     a, b = a_int, b_int
     if a == 0:
-        return _divisors(b)
+        return cast("Vector", _divisors(b))
     elif b == 0:
-        return _divisors(a)
+        return cast("Vector", _divisors(a))
 
     smaller = int(min(a, b))
-    common_divisors = [i for i in _divisors(smaller) if a % i == 0 and b % i == 0]
+    common_divisors: Vector = [
+        i for i in _divisors(smaller) if a % i == 0 and b % i == 0
+    ]
 
     return common_divisors
 
@@ -164,7 +167,7 @@ def round_to_clean_number(value: float, round_down: bool = False) -> float:
     return rounded_value
 
 
-def nested_defaultdict() -> defaultdict:
+def nested_defaultdict() -> "defaultdict[object, object]":
     return defaultdict(nested_defaultdict)
 
 

--- a/charted/utils/layout_engine.py
+++ b/charted/utils/layout_engine.py
@@ -131,7 +131,7 @@ class LayoutEngine:
             Total top padding in pixels (base padding + title height if present).
         """
         v_pad = self.v_padding * self.height
-        offset = 0
+        offset: float = 0
 
         if self.title:
             offset += self.title.height * 1.5
@@ -207,8 +207,8 @@ class LayoutEngine:
 
         from .helpers import calculate_rotation_angle
 
-        rotation_angle = 0
-        width = 0
+        rotation_angle: float = 0
+        width: float = 0
 
         for label in self.x_labels:
             angle = calculate_rotation_angle(label.width, x_width)
@@ -218,7 +218,7 @@ class LayoutEngine:
 
         return (rotation_angle, width) if rotation_angle else None
 
-    def get_base_transform(self) -> list:
+    def get_base_transform(self) -> list[str]:
         """Get base transformation matrix for chart coordinates.
 
         Returns:

--- a/charted/utils/line_renderer.py
+++ b/charted/utils/line_renderer.py
@@ -6,9 +6,47 @@ and address long function issues (Issue #70).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Protocol, cast
+
 from charted.html.element import Circle, G, Path, Rect
 from charted.utils.color_manager import ColorManager
 from charted.utils.curves import curve_path
+
+if TYPE_CHECKING:
+    from charted.themes.core import Theme
+    from charted.utils.series_style import SeriesStyleConfig
+    from charted.utils.types import Vector2D
+
+
+class _LineHost(Protocol):
+    """Structural type for the line chart consumed by :class:`LineRenderer`.
+
+    Declared for the type checker only so the renderer can reference the chart's
+    attributes without importing the concrete (and, during this typing pass,
+    not-yet-typed) ``LineChart`` class.
+    """
+
+    theme: Theme
+    series_styles: list[SeriesStyleConfig] | None
+
+    @property
+    def plot_width(self) -> float: ...
+
+    @property
+    def x_offset(self) -> float: ...
+
+    @property
+    def x_count(self) -> int: ...
+
+    @property
+    def y_offsets(self) -> Vector2D: ...
+
+    @property
+    def y_values(self) -> Vector2D: ...
+
+    def get_base_transform(self) -> list[str]: ...
+
+    def _apply_stacking(self, y: float, y_offset: float) -> float: ...
 
 
 def round_coordinate(value: float, decimals: int = 1) -> float:
@@ -52,7 +90,7 @@ class LineRenderer:
     - Series styling (stroke, width, opacity, dash patterns)
     """
 
-    def __init__(self, chart):
+    def __init__(self, chart: _LineHost):
         """Initialize line renderer.
 
         Args:
@@ -140,7 +178,9 @@ class LineRenderer:
 
         # Extract style properties
         stroke = style.get("stroke") or color
-        stroke_width = style.get("stroke_width") or self.chart.theme.resolved_series_stroke_width
+        stroke_width = (
+            style.get("stroke_width") or self.chart.theme.resolved_series_stroke_width
+        )
         stroke_dasharray = style.get("stroke_dasharray")
         # Fall back to the chart's redundant dash cycle when this series has no
         # explicit dash of its own. No-op unless dash_cycle was enabled.
@@ -176,7 +216,14 @@ class LineRenderer:
             points.append((x, y))
 
             # Render marker if enabled (sits on the data point, not the curve)
-            marker = self._get_marker(x, y, style, stroke, marker_shape, marker_size)
+            marker = self._get_marker(
+                x,
+                y,
+                style,
+                cast("str", stroke),
+                cast("str", marker_shape),
+                cast("float", marker_size),
+            )
             if marker:
                 markers.append(marker)
 
@@ -202,7 +249,7 @@ class LineRenderer:
 
         g.add_children(series)
 
-    def _get_series_style(self, index: int) -> dict:
+    def _get_series_style(self, index: int) -> dict[str, object]:
         """Get effective style for a series, merging theme defaults with overrides.
 
         Args:
@@ -217,7 +264,7 @@ class LineRenderer:
         # Apply per-series override if available
         if self.chart.series_styles and index < len(self.chart.series_styles):
             override = self.chart.series_styles[index] or {}
-            style = {**base_style, **override}
+            style = {**base_style, **cast("dict[str, object]", override)}
         else:
             style = dict(base_style)
 
@@ -232,7 +279,7 @@ class LineRenderer:
         self,
         x: float,
         y: float,
-        style: dict,
+        style: dict[str, object],
         stroke: str,
         marker_shape: str,
         marker_size: float,

--- a/charted/utils/patterns.py
+++ b/charted/utils/patterns.py
@@ -47,7 +47,9 @@ def resolve_pattern_cycle(spec: list[str] | bool | None) -> list[str] | None:
     return None
 
 
-def _pattern_geometry(name: str, color: str, size: float, stroke_width: float):
+def _pattern_geometry(
+    name: str, color: str, size: float, stroke_width: float
+) -> list[Element]:
     """Return the child SVG element(s) drawing one pattern's geometry."""
     from charted.html.element import Circle, Path
 

--- a/charted/utils/radar_renderer.py
+++ b/charted/utils/radar_renderer.py
@@ -7,14 +7,42 @@ and address long function issues (Issue #70).
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING, Protocol, cast
 
 from charted.constants import (
     DEFAULT_PADDING,
     FULL_CIRCLE,
     RIGHT_ANGLE,
 )
-from charted.html.element import Circle, G, Path, Rect, Text
+from charted.html.element import Circle, Element, G, Path, Rect, Text
 from charted.utils.defaults import DEFAULT_FONT, DEFAULT_FONT_SIZE
+
+if TYPE_CHECKING:
+    from charted.themes.core import Theme
+    from charted.utils.series_style import SeriesStyleConfig
+
+
+class _RadarHost(Protocol):
+    """Structural type for the radar chart consumed by :class:`RadarRenderer`.
+
+    Declared for the type checker only so the renderer can reference the chart's
+    attributes without importing the concrete (and, during this typing pass,
+    not-yet-typed) ``RadarChart`` class.
+    """
+
+    width: float
+    height: float
+    radius: float
+    grid_levels: int
+    label_offset: float
+    show_axis_labels: bool
+    colors: list[str]
+    theme: Theme
+    series_styles: list[SeriesStyleConfig] | None
+    _radar_labels: list[str]
+    _series_data: list[list[float]]
+
+    def get_base_transform(self) -> list[str]: ...
 
 
 class RadarRenderer:
@@ -27,7 +55,7 @@ class RadarRenderer:
     - Data series polygons and markers
     """
 
-    def __init__(self, chart):
+    def __init__(self, chart: _RadarHost):
         """Initialize radar renderer.
 
         Args:
@@ -85,8 +113,8 @@ class RadarRenderer:
         theme = self.chart.theme
         resolved = getattr(theme, "resolved_grid_color", None)
         if resolved:
-            return resolved
-        return getattr(theme, "grid_color", "#e0e0e0")
+            return cast("str", resolved)
+        return cast("str", getattr(theme, "grid_color", "#e0e0e0"))
 
     def _ring_label_color(self) -> str:
         """High-contrast colour for the numeric ring labels.
@@ -98,8 +126,8 @@ class RadarRenderer:
         theme = self.chart.theme
         resolved = getattr(theme, "resolved_label_color", None)
         if resolved:
-            return resolved
-        return getattr(theme, "title_color", "#333")
+            return cast("str", resolved)
+        return cast("str", getattr(theme, "title_color", "#333"))
 
     def _ring_label_halo(self) -> str:
         """Background colour used as a halo behind ring labels.
@@ -360,7 +388,7 @@ class RadarRenderer:
             max_value: Maximum value for scaling
         """
         # Get effective style for this series
-        style = {}
+        style: SeriesStyleConfig = {}
         if self.chart.series_styles and series_idx < len(self.chart.series_styles):
             style = self.chart.series_styles[series_idx] or {}
 
@@ -390,7 +418,13 @@ class RadarRenderer:
             g.add_child(polygon)
 
             # Render markers
-            self._render_markers(g, points, marker_shape, marker_size, stroke)
+            self._render_markers(
+                g,
+                points,
+                cast("str", marker_shape),
+                cast("float", marker_size),
+                cast("str", stroke),
+            )
 
     def _render_markers(
         self,
@@ -410,6 +444,7 @@ class RadarRenderer:
             stroke: Marker fill color
         """
         for x, y in points:
+            marker: Element
             if marker_shape == "circle":
                 marker = Circle(
                     cx=x,
@@ -499,6 +534,7 @@ class RadarRenderer:
         Returns:
             Tuple of (x, y) coordinates
         """
+        radius: float
         if max_value == 0:
             radius = 0
         else:

--- a/charted/utils/rendering.py
+++ b/charted/utils/rendering.py
@@ -240,10 +240,7 @@ def create_legend_entry(
     )
 
     g = G()
-    # Element.add_children types *children as list[Element] but at runtime
-    # accepts individual Elements (it iterates and appends each), which is how
-    # every caller uses it. Fixing the signature lives in html/element.py.
-    g.add_children(rect, legend_text)  # type: ignore[arg-type]
+    g.add_children(rect, legend_text)
     return g
 
 

--- a/charted/utils/rendering.py
+++ b/charted/utils/rendering.py
@@ -3,6 +3,7 @@
 Extracted from Chart class to reduce coupling and improve testability.
 """
 
+from typing import Any
 from urllib.parse import quote
 
 from charted.html.element import G, Path, Rect, Text
@@ -239,14 +240,17 @@ def create_legend_entry(
     )
 
     g = G()
-    g.add_children(rect, legend_text)
+    # Element.add_children types *children as list[Element] but at runtime
+    # accepts individual Elements (it iterates and appends each), which is how
+    # every caller uses it. Fixing the signature lives in html/element.py.
+    g.add_children(rect, legend_text)  # type: ignore[arg-type]
     return g
 
 
 def create_legend(
     series_names: list[str],
     colors: list[str],
-    theme_config: dict,
+    theme_config: "Theme | dict[str, Any]",
     plot_left: float,
     plot_right: float,
     top_padding: float,
@@ -357,7 +361,7 @@ def create_legend(
 def create_pie_legend(
     series_names: list[str],
     colors: list[str],
-    theme_config: dict,
+    theme_config: "Theme | dict[str, Any]",
     chart_width: float,
     chart_height: float,
 ) -> G | None:

--- a/charted/utils/series_legend.py
+++ b/charted/utils/series_legend.py
@@ -14,7 +14,48 @@ identical.
 
 from __future__ import annotations
 
-from charted.html.element import G, Rect, Text
+from typing import TYPE_CHECKING, Protocol, cast
+
+from charted.html.element import Element, G, Rect, Text
+
+if TYPE_CHECKING:
+    from charted.themes.core import Theme
+
+
+class _LegendHost(Protocol):
+    """Structural type for the chart that hosts the :class:`SeriesLegend` mixin.
+
+    Used only by the type checker (via :func:`typing.cast`) so the mixin can
+    reference host-provided attributes without coupling to a concrete chart
+    class. It introduces no runtime members on the mixin or its hosts.
+    """
+
+    @property
+    def colors(self) -> list[str]: ...
+
+    @property
+    def series_names(self) -> list[str] | None: ...
+
+    @property
+    def theme(self) -> Theme: ...
+
+    @property
+    def left_padding(self) -> float: ...
+
+    @property
+    def top_padding(self) -> float: ...
+
+    @property
+    def bottom_padding(self) -> float: ...
+
+    @property
+    def plot_width(self) -> float: ...
+
+    @property
+    def plot_height(self) -> float: ...
+
+    def _default_legend(self) -> G | None: ...
+
 
 VALID_LEGEND_PLACEMENTS = ("none", "right", "bottom", "top")
 
@@ -84,7 +125,7 @@ class SeriesLegend:
         names = getattr(self, "series_names", None)
         if not names:
             return []
-        colors = self.colors
+        colors = cast("_LegendHost", self).colors
         category_fill = getattr(self, "_category_fill", None)
         entries: list[tuple[str, str, str]] = []
         for idx, name in enumerate(names):
@@ -98,7 +139,7 @@ class SeriesLegend:
     # ------------------------------------------------------------------
 
     def _legend_font_size(self) -> float:
-        return self.theme.legend_font_size
+        return cast("_LegendHost", self).theme.legend_font_size
 
     def _legend_reserved_extent(self) -> float:
         """Pixel band to reserve for the legend on its placement side.
@@ -130,7 +171,7 @@ class SeriesLegend:
     # ------------------------------------------------------------------
 
     @property
-    def legend(self):
+    def legend(self) -> G | None:
         """Render the series legend in the band reserved by the layout.
 
         When ``legend='none'`` (the default), defers to the host's previous
@@ -138,25 +179,26 @@ class SeriesLegend:
         unchanged. Otherwise draws one swatch + label per series in the chosen
         band.
         """
+        host = cast("_LegendHost", self)
         if getattr(self, "_legend_placement", "none") == "none":
-            return self._default_legend()
+            return host._default_legend()
 
         entries = self._legend_entries()
         if not entries:
             return None
 
         font_size = self._legend_font_size()
-        font_family = self.theme.legend_font_family
-        font_color = self.theme.legend_font_color
+        font_family = host.theme.legend_font_family
+        font_color = host.theme.legend_font_color
         swatch = font_size
         gap = 6
         pad = 8
         row_h = font_size + 6
 
-        lp = self.left_padding
-        tp = self.top_padding
-        pw = self.plot_width
-        ph = self.plot_height
+        lp = host.left_padding
+        tp = host.top_padding
+        pw = host.plot_width
+        ph = host.plot_height
 
         g = G()
 
@@ -202,7 +244,7 @@ class SeriesLegend:
             # of the chart, below the x-axis tick labels. The bottom padding is
             # base label space + this legend band, so anchoring to the chart's
             # bottom edge keeps the legend clear of the axis labels.
-            bottom_edge = tp + ph + self.bottom_padding
+            bottom_edge = tp + ph + host.bottom_padding
             cy = bottom_edge - band + row_h / 2
         for (name, color, shape), w in zip(entries, widths):
             cx = x + swatch / 2
@@ -222,7 +264,9 @@ class SeriesLegend:
             x += w + item_gap
         return g
 
-    def _legend_swatch(self, shape: str, cx: float, cy: float, size: float, color: str):
+    def _legend_swatch(
+        self, shape: str, cx: float, cy: float, size: float, color: str
+    ) -> Element | None:
         """Build the swatch element for one legend row.
 
         Charts that draw shaped markers (scatter) provide ``_marker_element``;
@@ -234,7 +278,7 @@ class SeriesLegend:
             mark = marker(shape, cx, cy, size, color)
             if mark is not None:
                 mark.kwargs["fill"] = color
-                return mark
+                return cast("Element", mark)
             return None
         # Default square chip.
         return Rect(
@@ -243,17 +287,17 @@ class SeriesLegend:
 
     def _legend_add_entry(
         self,
-        g,
-        name,
-        color,
-        shape,
-        cx,
-        cy,
-        text_x,
-        font_size,
-        font_family,
-        font_color,
-        text_baseline=None,
+        g: G,
+        name: str,
+        color: str,
+        shape: str,
+        cx: float,
+        cy: float,
+        text_x: float,
+        font_size: float,
+        font_family: str,
+        font_color: str,
+        text_baseline: float | None = None,
     ) -> None:
         """Add one swatch + label to the legend group ``g``."""
         mark = self._legend_swatch(shape, cx, cy, font_size / 2, color)

--- a/charted/utils/series_style.py
+++ b/charted/utils/series_style.py
@@ -123,7 +123,7 @@ class SeriesStyle:
         """
         return dataclasses.replace(self, _marker_size=size)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> object:
         """Provide backward-compatible attribute access for dict-style usage.
 
         Allows code like `style["fill"]` or `style.fill` to work with SeriesStyle.
@@ -145,20 +145,20 @@ class SeriesStyle:
             return getattr(self, internal_name)
         raise AttributeError(f"'{type(self).__name__}' has no attribute '{name}'")
 
-    def get(self, key: str, default=None):
+    def get(self, key: str, default: object = None) -> object:
         """Dict-style get method for backward compatibility."""
         try:
             return getattr(self, key)
         except AttributeError:
             return default
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, object]:
         """Convert to dictionary for backward compatibility.
 
         Returns:
             Dictionary with all non-None properties.
         """
-        result = {}
+        result: dict[str, object] = {}
         if self._fill is not None:
             result["fill"] = self._fill
         if self._stroke is not None:
@@ -177,4 +177,4 @@ class SeriesStyle:
 
 
 # Backward compatibility alias
-SeriesStyleConfig = SeriesStyle | dict
+SeriesStyleConfig = SeriesStyle | dict[str, object]

--- a/charted/utils/theme_manager.py
+++ b/charted/utils/theme_manager.py
@@ -4,10 +4,10 @@ Extracted from Chart class to reduce coupling and improve testability.
 This module encapsulates all theme loading and merging logic.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from .themes import Theme
+    from charted.themes.core import Theme
 
 
 class ThemeManager:
@@ -26,7 +26,8 @@ class ThemeManager:
 
     @staticmethod
     def load_theme(
-        theme: "Theme | str | dict | None", chart_type: str | None = None
+        theme: "Theme | str | dict[str, object] | None",
+        chart_type: str | None = None,
     ) -> "Theme":
         """Load base theme and apply chart-type overrides.
 
@@ -79,7 +80,7 @@ class ThemeManager:
         return base_theme
 
 
-def _dict_to_theme(data: dict) -> "Theme":
+def _dict_to_theme(data: dict[str, object]) -> "Theme":
     """Convert a dict to Theme object (backward compatibility).
 
     Args:
@@ -96,7 +97,7 @@ def _dict_to_theme(data: dict) -> "Theme":
     from charted.themes.core import Theme
 
     # Map dict keys to Theme fields - only allow known fields
-    theme_data = {}
+    theme_data: dict[str, Any] = {}
     theme_fields = {f.name for f in fields(Theme)}
 
     for key, value in data.items():

--- a/charted/utils/types.py
+++ b/charted/utils/types.py
@@ -27,7 +27,9 @@ class PointStyleConfig(TypedDict, total=False):
     style (``series_styles``)/shape-cycle resolution and finally the defaults.
     """
 
-    marker_shape: str | None  # "circle" | "square" | "diamond" | "triangle" | "star" | "none"
+    marker_shape: (
+        str | None
+    )  # "circle" | "square" | "diamond" | "triangle" | "star" | "none"
     marker_size: float | None
     fill: str | None
     opacity: float | None
@@ -57,7 +59,9 @@ class Coordinate(NamedTuple):
 class AxisDimension(NamedTuple):
     min_value: float
     max_value: float
-    count: float
+    # `count` shadows tuple.count; keeping the public field name (used widely as
+    # AxisDimension.count) means accepting this known NamedTuple/mypy clash.
+    count: float  # type: ignore[assignment]
 
     @property
     def value_range(self) -> float:

--- a/charted/utils/validation.py
+++ b/charted/utils/validation.py
@@ -3,6 +3,8 @@
 Extracted from Chart class to reduce coupling and improve testability.
 """
 
+from typing import cast
+
 from charted.utils.exceptions import (
     DataShapeError,
     InvalidValue,
@@ -11,7 +13,7 @@ from charted.utils.exceptions import (
 from charted.utils.types import Vector, Vector2D
 
 
-def validate_data(data: Vector | Vector2D | None) -> Vector2D:
+def validate_data(data: Vector | Vector2D | None) -> Vector2D | None:
     """Validate and normalize chart data.
 
     Args:
@@ -31,18 +33,20 @@ def validate_data(data: Vector | Vector2D | None) -> Vector2D:
 
     # Normalize to 2D
     if type(data[0]) is not list:
-        data = [data]
+        normalized: Vector2D = [cast("Vector", data)]
+    else:
+        normalized = data
 
-    max_length = max([len(i) for i in data])
+    max_length = max([len(i) for i in normalized])
 
-    if not all([len(i) == max_length for i in data]):
+    if not all([len(i) == max_length for i in normalized]):
         raise DataShapeError(
             expected=f"all series length {max_length}",
             actual="series lengths differ",
-            detail=f"Series lengths: {[len(i) for i in data]}",
+            detail=f"Series lengths: {[len(i) for i in normalized]}",
         )
 
-    return data
+    return normalized
 
 
 def validate_attribute_value(name: str, value: float) -> float:
@@ -81,7 +85,7 @@ def validate_padding(value: float, max_value: float = 1.0) -> float:
     return validate_attribute_value("padding", value)
 
 
-def validate_series_count(series_styles: list | None, target: int) -> int:
+def validate_series_count(series_styles: list[object] | None, target: int) -> int:
     """Validate and normalize series count.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,8 @@ packages = ["charted", "duckdb_ext", "mcp_server"]
 # so are not picked up by `packages` alone.
 force-include = { "charted/py.typed" = "charted/py.typed" }
 artifacts = ["charted/fonts/definitions/*.json"]
+
+[tool.mypy]
+python_version = "3.10"
+files = ["charted"]
+strict = true


### PR DESCRIPTION
The charted package now passes `mypy --strict`. The starting state reported 461 errors; the branch brings that to 0 across all 64 source files.

All changes are type-only. There are no runtime behavior changes and no baseline changes. The work is split per area: utils core, render/html, CLI/config/themes/fonts, axes, scales, the bar/column/combo charts, pie/gantt/scatter/annotations, and the remaining charts. A `[tool.mypy]` strict config for the package was added.

The residual `# type: ignore` comments are all narrow and justified:

- `charted/config.py` (2): `tomllib`/`tomli` import fallback for the 3.10 vs 3.11+ split (`import-not-found`).
- `charted/fonts/tkinter.py` (2): `tk`/`tkfont` set to `None` when tkinter is unavailable at import time.
- `charted/charts/chart.py:171`: `cairosvg` is an untyped third-party import (`import-untyped`).
- `charted/utils/data_input.py:150`: `pandas` is an untyped third-party import (`import-untyped`).
- `charted/themes/core.py:724`: reassigning `Theme.__init__` at runtime (`method-assign`).
- `charted/utils/types.py:64`: intentional field override (`assignment`).
- `charted/charts/combo.py:117`: mixin MRO that mypy rejects but is correct at runtime (`misc`).
- `charted/utils/data_model.py` (2): property accessors returning internal storage that mypy can't narrow.

Note: a CI step running mypy still needs to be added to `.github/workflows/ci.yml` separately. That edit touches a workflow file and requires a workflow-scope push that this push did not include.
