### PR TITLE
types: ban explicit Any (mypy disallow_any_explicit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,27 +37,11 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e '.[dev]'
 
-      - name: Debug Python version and packages
-        run: |
-          echo "Python version:"
-          python --version
-          echo ""
-          echo "Installed pytest packages:"
-          pip list | grep -E "(pytest|coverage)"
-          echo ""
-          echo "pytest-cov version info:"
-          pip show pytest-cov
-          echo ""
-          echo "coverage version info:"
-          pip show coverage
-
-      - name: Debug test collection
-        run: |
-          echo "Attempting to collect tests..."
-          pytest --collect-only --quiet || echo "Test collection failed!"
-
       - name: Run ruff linter
         run: ruff check .
+
+      - name: Run mypy (strict, no explicit Any)
+        run: mypy
 
       - name: Run tests with coverage
         run: |

--- a/charted/chart_config.py
+++ b/charted/chart_config.py
@@ -22,16 +22,26 @@ from __future__ import annotations
 
 import dataclasses
 import sys
-from typing import Any
 
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
 
+from collections.abc import Mapping
+from typing import Protocol, TypeVar, cast
+
 from charted.themes.core import Theme
 from charted.utils.series_style import SeriesStyleConfig
-from charted.utils.types import Labels, Vector
+from charted.utils.types import ComboSeriesDict, Labels, Vector
+
+_C = TypeVar("_C", covariant=True)
+
+
+class _ConfigFactory(Protocol[_C]):
+    """Callable building a config object from keyword-only field values."""
+
+    def __call__(self, **kwargs: object) -> _C: ...
 
 
 @dataclasses.dataclass
@@ -73,7 +83,7 @@ class ChartConfig:
     x_scale: object | None = None
     y_scale: object | None = None
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, object]:
         """Convert config to dictionary for serialization.
 
         Returns:
@@ -87,7 +97,7 @@ class ChartConfig:
         return dataclasses.asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
+    def from_dict(cls, data: Mapping[str, object]) -> Self:
         """Create config from dictionary.
 
         Args:
@@ -100,9 +110,14 @@ class ChartConfig:
             >>> config = ChartConfig.from_dict({'width': 600, 'title': 'Test'})
         """
         valid_fields = {f.name for f in dataclasses.fields(cls)}
-        return cls(**{k: v for k, v in data.items() if k in valid_fields})
+        filtered = {k: v for k, v in data.items() if k in valid_fields}
+        # The dataclass fields are heterogeneously typed, so a dynamically
+        # filtered kwargs mapping cannot be checked against the constructor
+        # signature statically. The cast confines that one dynamic call.
+        factory = cast("_ConfigFactory[Self]", cls)
+        return factory(**filtered)
 
-    def update(self, **kwargs: Any) -> Self:
+    def update(self, **kwargs: object) -> Self:
         """Update config with new values and return self.
 
         Args:
@@ -213,7 +228,7 @@ class ComboChartConfig(ChartConfig):
     """
 
     # Combo-specific settings
-    series: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    series: list[ComboSeriesDict] = dataclasses.field(default_factory=list)
     column_gap: float = 0.20
 
     # Labels

--- a/charted/charts/area.py
+++ b/charted/charts/area.py
@@ -5,14 +5,23 @@ Shows one or more series as filled regions under the line.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path
 from charted.themes.core import Theme
 from charted.utils.curves import VALID_CURVES, curve_path
-from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+from charted.utils.types import (
+    Labels,
+    ReferenceLineDict,
+    SeriesStyleConfig,
+    Vector,
+    Vector2D,
+)
+
+if TYPE_CHECKING:
+    from charted.charts.chart import _Annotation
 
 
 class AreaChart(Chart):
@@ -63,8 +72,8 @@ class AreaChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list[Any] | None = None,
-        reference_lines: list[dict[str, Any]] | None = None,
+        annotations: list[_Annotation] | None = None,
+        reference_lines: list[ReferenceLineDict] | None = None,
         colors: list[str] | None = None,
         domain_padding: float | None = None,
     ):

--- a/charted/charts/axes.py
+++ b/charted/charts/axes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
 from charted.constants import DEFAULT_PADDING
 from charted.html.element import Element, G, Path, Text
@@ -40,6 +40,21 @@ class _AxisParent(Protocol):
     x_label_rotation: tuple[float, float] | None
 
 
+class _TickLabeled(Protocol):
+    """Structural type for a scale that exposes formatted tick labels."""
+
+    def tick_labels(self) -> list[str]: ...
+
+
+class _GridMinorParams(TypedDict):
+    """Minor-grid parameters peeled off a dict grid config."""
+
+    divisions: int
+    stroke: str | None
+    stroke_width: float | None
+    stroke_dasharray: str
+
+
 class Axis(G):
     parent: _AxisParent
 
@@ -50,7 +65,7 @@ class Axis(G):
         labels: list[str] | None = None,
         stacked: bool = False,
         zero_index: bool = True,
-        config: str | None = None,
+        config: str | dict[str, object] | None = None,
         pad_labels: bool = True,
         scale: Scale | None = None,
     ):
@@ -97,7 +112,7 @@ class Axis(G):
         if hasattr(scale, "tick_labels"):
             self._labels = [
                 calculate_text_dimensions(text)
-                for text in cast("Any", scale).tick_labels()
+                for text in cast("_TickLabeled", scale).tick_labels()
             ]
         else:
             self.labels = [str(v) for v in tick_values]
@@ -275,8 +290,8 @@ class Axis(G):
 
     @staticmethod
     def _split_grid_config(
-        config: str | dict[str, Any],
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        config: str | dict[str, object],
+    ) -> tuple[dict[str, object], _GridMinorParams]:
         """Split a grid config into (major_attrs, minor_params).
 
         A string config becomes the historical single-weight attrs with no
@@ -284,13 +299,21 @@ class Axis(G):
         separately so the remaining keys can be splatted onto the major Path.
         """
         if isinstance(config, str):
-            return {"stroke": config, "stroke_dasharray": "None"}, {}
+            empty: _GridMinorParams = {
+                "divisions": 0,
+                "stroke": None,
+                "stroke_width": None,
+                "stroke_dasharray": "None",
+            }
+            return {"stroke": config, "stroke_dasharray": "None"}, empty
         major = dict(config)
-        minor = {
-            "divisions": major.pop("minor_divisions", 0),
-            "stroke": major.pop("minor_stroke", None),
-            "stroke_width": major.pop("minor_stroke_width", None),
-            "stroke_dasharray": major.pop("minor_stroke_dasharray", "None"),
+        minor: _GridMinorParams = {
+            "divisions": cast("int", major.pop("minor_divisions", 0)),
+            "stroke": cast("str | None", major.pop("minor_stroke", None)),
+            "stroke_width": cast("float | None", major.pop("minor_stroke_width", None)),
+            "stroke_dasharray": cast(
+                "str", major.pop("minor_stroke_dasharray", "None")
+            ),
         }
         return major, minor
 

--- a/charted/charts/bar.py
+++ b/charted/charts/bar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, cast
 
 from charted.charts.chart import Chart
 from charted.config import get_bar_gap
@@ -8,7 +8,16 @@ from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import Element, G, Path, Text
 from charted.themes.core import Theme
 from charted.utils.exceptions import NoDataError
-from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+from charted.utils.types import (
+    Labels,
+    ReferenceLineDict,
+    SeriesStyleConfig,
+    Vector,
+    Vector2D,
+)
+
+if TYPE_CHECKING:
+    from charted.charts.chart import _Annotation
 
 
 class BarChart(Chart):
@@ -60,10 +69,10 @@ class BarChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list[Any] | None = None,
-        reference_lines: list[dict[str, Any]] | None = None,
+        annotations: list[_Annotation] | None = None,
+        reference_lines: list[ReferenceLineDict] | None = None,
         colors: list[str] | None = None,
-        value_labels: bool | str | dict[str, Any] | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
         legend: str = "none",
         category_label_max_width: float | None = None,
         category_patterns: list[str] | bool | None = None,

--- a/charted/charts/box.py
+++ b/charted/charts/box.py
@@ -5,13 +5,13 @@ Displays median, quartiles, and outliers for one or more data series.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import cast
 
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path, Rect, Text
 from charted.themes.core import Theme
-from charted.utils.types import Labels, Vector2D
+from charted.utils.types import Labels, ValueLabelOptions, Vector2D
 
 
 def _quartiles(data: list[float]) -> tuple[float, float, float, float, float]:
@@ -62,7 +62,7 @@ class BoxPlot(Chart):
         title: str | None = None,
         theme: Theme | None = None,
         series_names: list[str] | None = None,
-        value_labels: bool | str | dict[str, Any] | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
         legend: str = "none",
     ):
         self._raw_data = data
@@ -163,7 +163,10 @@ class BoxPlot(Chart):
                 from charted.utils.value_format import format_value
 
                 cfg = self._value_label_config
-                opts = {k: v for k, v in cfg.items() if k != "format"}
+                opts = cast(
+                    "ValueLabelOptions",
+                    {k: v for k, v in cfg.items() if k != "format"},
+                )
                 font_size = max(8, self.theme.title_font_size - 4)
                 g.add_child(
                     Text(

--- a/charted/charts/bubble.py
+++ b/charted/charts/bubble.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from charted.charts.scatter import ScatterChart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
@@ -105,7 +105,7 @@ class BubbleChart(ScatterChart):
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
         quadrant_labels: list[str] | None = None,
-        value_labels: bool | str | dict[str, Any] | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
         legend: str = "none",
         domain_padding: float | None = None,
     ):
@@ -624,7 +624,7 @@ class BubbleChart(ScatterChart):
                 )
             )
 
-    def to_config(self) -> dict[str, Any]:
+    def to_config(self) -> dict[str, object]:
         cfg = super().to_config()
         cfg["sizes"] = list(self.sizes)
         cfg["min_radius"] = self.min_radius

--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -6,7 +6,7 @@ separate modules to address God Class architectural debt (Issue #64).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 from charted.charts.axes import XAxis, YAxis
 from charted.constants import (
@@ -30,7 +30,10 @@ from charted.utils.transform import translate
 from charted.utils.types import (
     Labels,
     MeasuredText,
+    ReferenceLineDict,
     SeriesStyleConfig,
+    ValueLabelConfig,
+    ValueLabelOptions,
     Vector,
     Vector2D,
 )
@@ -38,7 +41,19 @@ from charted.utils.types import (
 if TYPE_CHECKING:
     from charted.charts.axes import _AxisParent
     from charted.charts.scales import Scale
-    from charted.html.element import Title
+    from charted.html.element import Element, Title
+    from charted.utils.patterns import Pattern
+
+
+class _Annotation(Protocol):
+    """Structural type for a chart annotation.
+
+    The three concrete annotation dataclasses (line, box, label) all expose a
+    ``render`` method that draws the annotation against a chart; this Protocol
+    captures that single contract without importing the concrete classes.
+    """
+
+    def render(self, chart: Chart) -> Element: ...
 
 
 class Chart(SeriesLegend, Svg):
@@ -180,7 +195,7 @@ class Chart(SeriesLegend, Svg):
                 f"Unsupported file extension '{ext}'. Supported: .svg, .png"
             )
 
-    def style(self, **kwargs: Any) -> "Chart":
+    def style(self, **kwargs: object) -> "Chart":
         """Fluently apply theme overrides.
 
         Args:
@@ -195,12 +210,15 @@ class Chart(SeriesLegend, Svg):
         """
         from charted.themes.core import Theme
 
-        # Build an override Theme from kwargs
-        override = Theme(**{k: v for k, v in kwargs.items() if hasattr(Theme, k)})
+        # Build an override Theme from kwargs. Theme's runtime ``__init__`` takes
+        # arbitrary keyword overrides (it replaces the dataclass-synthesised one),
+        # so the heterogeneous override mapping is splatted in directly.
+        overrides = {k: v for k, v in kwargs.items() if hasattr(Theme, k)}
+        override = Theme(**overrides)  # type: ignore[arg-type]
         self.theme = self.theme.compose(override)
         return self
 
-    def to_config(self) -> dict[str, Any]:
+    def to_config(self) -> dict[str, object]:
         """Serialize chart configuration to a dict.
 
         Returns a dict with all constructor parameters needed to
@@ -211,7 +229,7 @@ class Chart(SeriesLegend, Svg):
         """
         import dataclasses
 
-        cfg: dict[str, Any] = {
+        cfg: dict[str, object] = {
             "chart_type": self.__class__.__name__,
             "width": self._width,
             "height": self._height,
@@ -248,7 +266,7 @@ class Chart(SeriesLegend, Svg):
         return cfg
 
     @staticmethod
-    def _serialize_annotation(a: Any) -> Any:
+    def _serialize_annotation(a: object) -> object:
         """Serialize one annotation to a JSON-friendly dict.
 
         Tags the dict with its class name and strips private ``_ref_*`` fields
@@ -257,17 +275,13 @@ class Chart(SeriesLegend, Svg):
         """
         import dataclasses
 
-        if not dataclasses.is_dataclass(a):
+        if not dataclasses.is_dataclass(a) or isinstance(a, type):
             return a
-        data = {
-            k: v
-            for k, v in dataclasses.asdict(cast("Any", a)).items()
-            if not k.startswith("_")
-        }
+        data = {k: v for k, v in dataclasses.asdict(a).items() if not k.startswith("_")}
         return {"type": a.__class__.__name__, **data}
 
     @classmethod
-    def from_config(cls, config: dict[str, Any], **overrides: Any) -> "Chart":
+    def from_config(cls, config: dict[str, object], **overrides: object) -> "Chart":
         """Recreate a chart from a config dict.
 
         Merges ``overrides`` on top of ``config`` so agents can tweak
@@ -289,12 +303,13 @@ class Chart(SeriesLegend, Svg):
 
         # Reconstruct annotation objects from their serialized dict form.
         # to_config() emits each annotation as {"type": <ClassName>, **asdict(a)}.
-        if "annotations" in merged:
-            merged["annotations"] = cls._rebuild_annotations(merged["annotations"])
+        raw_annotations = merged.get("annotations")
+        if isinstance(raw_annotations, list):
+            merged["annotations"] = cls._rebuild_annotations(raw_annotations)
 
         chart_type = merged.pop("chart_type", None)
         cls_map = _CHART_CLASSES()
-        chart_cls = cls_map.get(chart_type, cls)
+        chart_cls = cls_map.get(chart_type, cls) if isinstance(chart_type, str) else cls
         if chart_cls is None:
             chart_cls = cls
 
@@ -312,10 +327,13 @@ class Chart(SeriesLegend, Svg):
         if "y_data" in valid_params and "y_data" not in filtered and "data" in merged:
             filtered["y_data"] = merged["data"]
 
-        return chart_cls(**filtered)
+        # ``filtered`` is a deserialised config whose values are statically
+        # ``object``; they are dispatched into the resolved subclass constructor
+        # at runtime after being filtered to that constructor's parameters.
+        return chart_cls(**filtered)  # type: ignore[arg-type]
 
     @staticmethod
-    def _rebuild_annotations(annotations: list[Any]) -> list[Any]:
+    def _rebuild_annotations(annotations: list[object]) -> list[object]:
         """Reconstruct annotation objects from their serialized dict form.
 
         ``to_config()`` serializes each annotation as
@@ -342,16 +360,16 @@ class Chart(SeriesLegend, Svg):
         # Fields that are (x, y) / (min, max) pairs and must be tuples.
         tuple_fields = {"start", "end", "x_range", "y_range", "point"}
 
-        rebuilt: list[Any] = []
+        rebuilt: list[object] = []
         for a in annotations:
             # Already an annotation object (not a serialized dict): keep as-is.
             if not isinstance(a, dict):
                 rebuilt.append(a)
                 continue
 
-            data = dict(a)
+            data: dict[str, object] = {str(k): v for k, v in a.items()}
             type_name = data.pop("type", None)
-            ann_cls = type_map.get(type_name)
+            ann_cls = type_map.get(type_name) if isinstance(type_name, str) else None
             if ann_cls is None:
                 # Unknown type: leave the raw dict untouched rather than guess.
                 rebuilt.append(a)
@@ -361,8 +379,9 @@ class Chart(SeriesLegend, Svg):
             data = {k: v for k, v in data.items() if not k.startswith("_")}
             # Coerce JSON lists back to tuples for coordinate pairs.
             for key in tuple_fields:
-                if key in data and isinstance(data[key], list):
-                    data[key] = tuple(data[key])
+                value = data.get(key)
+                if isinstance(value, list):
+                    data[key] = tuple(value)
 
             rebuilt.append(ann_cls(**data))
         return rebuilt
@@ -386,22 +405,22 @@ class Chart(SeriesLegend, Svg):
         title: str | None = None,
         subtitle: str | None = None,
         subtitle_leading: float = 8.0,
-        theme: Theme | str | dict[str, Any] | None = None,
+        theme: Theme | str | dict[str, object] | None = None,
         chart_type: str | None = None,
         x_label: str | None = None,
         y_label: str | None = None,
         data_labels: list[str] | list[list[str]] | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list[Any] | None = None,
+        annotations: list[_Annotation] | None = None,
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict[str, Any]] | None = None,
+        reference_lines: list[ReferenceLineDict] | None = None,
         colors: list[str] | None = None,
         x_range: tuple[float, float] | None = None,
         y_range: tuple[float, float] | None = None,
         domain_padding: float | None = None,
-        value_labels: bool | str | dict[str, Any] | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
         legend: str = "none",
         category_label_max_width: float | None = None,
         category_patterns: list[str] | bool | None = None,
@@ -498,7 +517,7 @@ class Chart(SeriesLegend, Svg):
         self._v_lines: list[float] | None = v_lines or []
 
         # Parse reference_lines convenience API into h_lines/v_lines + labels
-        self._reference_line_labels: list[dict[str, Any]] = []
+        self._reference_line_labels: list[ReferenceLineDict] = []
         if reference_lines:
             from charted.utils.exceptions import ValidationError
 
@@ -637,7 +656,7 @@ class Chart(SeriesLegend, Svg):
                 if (x_data is not None and x_labels is not None)
                 else self.zero_index
             ),
-            config=cast("str | None", grid_config),
+            config=grid_config,
             pad_labels=self.pad_x_labels,
             scale=x_scale_inst,
         )
@@ -648,7 +667,7 @@ class Chart(SeriesLegend, Svg):
             labels=y_labels,
             stacked=self.y_stacked,
             zero_index=self.zero_index,
-            config=cast("str | None", grid_config),
+            config=grid_config,
             scale=y_scale_inst,
         )
 
@@ -851,7 +870,7 @@ class Chart(SeriesLegend, Svg):
         colors = getattr(self, "colors", None) or []
         return len(colors)
 
-    def _pattern_defs(self) -> list[Any]:
+    def _pattern_defs(self) -> list[Pattern]:
         """Build one ``<pattern>`` def per (category, pattern) the chart uses.
 
         Returns an empty list unless ``category_patterns`` was enabled, so the
@@ -865,7 +884,7 @@ class Chart(SeriesLegend, Svg):
         from charted.utils.patterns import build_pattern
 
         colors = getattr(self, "colors", None) or []
-        defs: list[Any] = []
+        defs: list[Pattern] = []
         for idx, color in enumerate(colors):
             name = cycle[idx % len(cycle)]
             defs.append(build_pattern(self._pattern_id(idx), name, color))
@@ -886,7 +905,7 @@ class Chart(SeriesLegend, Svg):
             return color
         return f"url(#{self._pattern_id(index)})"
 
-    def _filled_outline_attrs(self) -> dict[str, Any]:
+    def _filled_outline_attrs(self) -> dict[str, object]:
         """Stroke attributes to apply to a filled shape, or ``{}`` when off.
 
         Reads the theme's ``filled_shape_outline``; when no outline colour is
@@ -1053,7 +1072,7 @@ class Chart(SeriesLegend, Svg):
         # data reach lo/hi without altering the plotted points themselves.
         return [*[list(row) for row in data], [lo, hi]]
 
-    def _build_grid_config(self) -> str | dict[str, Any]:
+    def _build_grid_config(self) -> str | dict[str, object]:
         """Assemble the gridline config passed to each axis.
 
         Returns the plain grid colour string when the theme requests no
@@ -1071,7 +1090,7 @@ class Chart(SeriesLegend, Svg):
         if width is None and dasharray is None and divisions <= 0:
             return color
 
-        config: dict[str, Any] = {
+        config: dict[str, object] = {
             "stroke": color,
             "stroke_dasharray": dasharray if dasharray is not None else "None",
         }
@@ -1423,7 +1442,7 @@ class Chart(SeriesLegend, Svg):
         from charted.utils.rendering import create_legend
 
         # Pass legend config as dict or Theme object
-        legend_config: dict[str, Any] = {
+        legend_config: dict[str, object] = {
             "font_size": self.theme.legend_font_size,
             "position": self.theme.legend_position,
             "font_family": self.theme.legend_font_family,
@@ -1445,7 +1464,7 @@ class Chart(SeriesLegend, Svg):
     # Introspection
     # =========================================================================
 
-    def describe(self) -> dict[str, Any]:
+    def describe(self) -> dict[str, object]:
         """Return a structured dictionary of chart metadata.
 
         Useful for AI agents that need to reason about a chart they just
@@ -1539,7 +1558,7 @@ class Chart(SeriesLegend, Svg):
     # Reference Lines & Axis Labels
     # =========================================================================
 
-    def _collect_legacy_reference_lines(self) -> list[Any]:
+    def _collect_legacy_reference_lines(self) -> list[_Annotation]:
         """Build the legacy ``h_lines`` / ``v_lines`` reference-line layer.
 
         These are expressed as dashed full-span ``LineAnnotation`` objects so
@@ -1550,14 +1569,14 @@ class Chart(SeriesLegend, Svg):
         """
         from charted.charts.annotations import LineAnnotation
 
-        annotations: list[Any] = []
+        annotations: list[_Annotation] = []
         if self._h_lines:
             annotations.extend(LineAnnotation._h_line(v) for v in self._h_lines)
         if self._v_lines:
             annotations.extend(LineAnnotation._v_line(v) for v in self._v_lines)
         return annotations
 
-    def _collect_annotations(self) -> list[Any]:
+    def _collect_annotations(self) -> list[_Annotation]:
         """Build the full annotation list for this chart.
 
         Legacy reference lines (``h_lines`` / ``v_lines``) come first, in their
@@ -1786,8 +1805,8 @@ class Chart(SeriesLegend, Svg):
 
     @staticmethod
     def _normalize_value_labels(
-        spec: bool | str | dict[str, Any] | None,
-    ) -> dict[str, Any] | None:
+        spec: bool | str | dict[str, object] | None,
+    ) -> ValueLabelConfig | None:
         """Coerce the ``value_labels`` argument into a config dict or None.
 
         Accepted forms:
@@ -1814,7 +1833,7 @@ class Chart(SeriesLegend, Svg):
         if isinstance(spec, str):
             return {"format": spec}
         if isinstance(spec, dict):
-            cfg = dict(spec)
+            cfg: ValueLabelConfig = cast("ValueLabelConfig", dict(spec))
             cfg.setdefault("format", "number")
             return cfg
         raise TypeError(
@@ -1842,7 +1861,10 @@ class Chart(SeriesLegend, Svg):
             return None
         from charted.utils.value_format import format_value
 
-        opts = {k: v for k, v in cfg.items() if k != "format"}
+        opts = cast(
+            "ValueLabelOptions",
+            {k: v for k, v in cfg.items() if k != "format"},
+        )
         fmt = cfg["format"]
         data = self._value_label_data()
         return [[format_value(v, fmt, **opts) for v in row] for row in data]

--- a/charted/charts/column.py
+++ b/charted/charts/column.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, cast
 
 from charted.charts.chart import Chart
 from charted.config import get_column_gap
@@ -8,7 +8,16 @@ from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Path
 from charted.themes.core import Theme
 from charted.utils.transform import translate
-from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+from charted.utils.types import (
+    Labels,
+    ReferenceLineDict,
+    SeriesStyleConfig,
+    Vector,
+    Vector2D,
+)
+
+if TYPE_CHECKING:
+    from charted.charts.chart import _Annotation
 
 
 class ColumnChart(Chart):
@@ -58,12 +67,12 @@ class ColumnChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list[Any] | None = None,
+        annotations: list[_Annotation] | None = None,
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict[str, Any]] | None = None,
+        reference_lines: list[ReferenceLineDict] | None = None,
         colors: list[str] | None = None,
-        value_labels: bool | str | dict[str, Any] | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
         legend: str = "none",
         category_patterns: list[str] | bool | None = None,
         domain_padding: float | None = None,

--- a/charted/charts/combo.py
+++ b/charted/charts/combo.py
@@ -7,7 +7,7 @@ that scales to its own range and renders tick labels on the right.
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from charted.charts.axes import XAxis, YAxis, _AxisParent
 from charted.charts.chart import Chart
@@ -19,7 +19,7 @@ from charted.utils.defaults import DEFAULT_FONT, DEFAULT_FONT_SIZE
 from charted.utils.layout_engine import LayoutEngine
 from charted.utils.line_renderer import LineRenderer, _LineHost
 from charted.utils.transform import translate
-from charted.utils.types import Labels, SeriesStyleConfig, Vector2D
+from charted.utils.types import ComboSeriesDict, Labels, SeriesStyleConfig, Vector2D
 
 _BAR_TYPES = {"bar", "column"}
 _LINE_TYPES = {"line", "area"}
@@ -206,7 +206,7 @@ class ComboChart(Chart):
 
     def __init__(
         self,
-        series: list[dict[str, Any]],
+        series: list[ComboSeriesDict],
         labels: Labels | None = None,
         width: float = DEFAULT_CHART_WIDTH,
         height: float = DEFAULT_CHART_HEIGHT,
@@ -224,7 +224,7 @@ class ComboChart(Chart):
         if not series or len(series) < 2:
             raise ValueError("ComboChart requires at least two series.")
 
-        normalized: list[dict[str, Any]] = []
+        normalized: list[ComboSeriesDict] = []
         for s in series:
             stype = s.get("type", "line")
             if stype not in _VALID_TYPES:
@@ -260,7 +260,10 @@ class ComboChart(Chart):
             self._secondary_indices = []
 
         series_names_list = [s["name"] for s in self.series]
-        names: list[Any] | None = series_names_list
+        # Series names may individually be ``None``; the base chart's
+        # ``series_names`` contract is ``list[str]`` but tolerates the optional
+        # entries at runtime (the legend skips unnamed series).
+        names = cast("list[str] | None", series_names_list)
         if all(n is None for n in series_names_list):
             names = None
 
@@ -393,7 +396,7 @@ class ComboChart(Chart):
             )
         return group
 
-    def describe(self) -> dict[str, Any]:
+    def describe(self) -> dict[str, object]:
         meta = super().describe()
         meta["chart_type"] = "ComboChart"
         meta["series_count"] = len(self.series)
@@ -416,7 +419,7 @@ class ComboChart(Chart):
         meta["series"] = series_info
         return meta
 
-    def to_config(self) -> dict[str, Any]:
+    def to_config(self) -> dict[str, object]:
         cfg = super().to_config()
         cfg["chart_type"] = "ComboChart"
         cfg["series"] = [dict(s) for s in self.series]

--- a/charted/charts/histogram.py
+++ b/charted/charts/histogram.py
@@ -6,13 +6,12 @@ Shows the frequency of values within evenly-spaced intervals.
 from __future__ import annotations
 
 import math
-from typing import Any
 
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 from charted.html.element import G, Rect
 from charted.themes.core import Theme
-from charted.utils.types import Vector
+from charted.utils.types import ReferenceLineDict, Vector
 
 
 def _auto_bins(data: list[float]) -> int:
@@ -76,9 +75,9 @@ class Histogram(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        reference_lines: list[dict[str, Any]] | None = None,
+        reference_lines: list[ReferenceLineDict] | None = None,
         colors: list[str] | None = None,
-        value_labels: bool | str | dict[str, Any] | None = None,
+        value_labels: bool | str | dict[str, object] | None = None,
         domain_padding: float | None = None,
     ):
         n_bins = bins if bins is not None else _auto_bins(data)

--- a/charted/charts/line.py
+++ b/charted/charts/line.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from charted.charts.chart import Chart
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
@@ -8,9 +8,16 @@ from charted.html.element import G, Text
 from charted.themes.core import Theme
 from charted.utils.curves import VALID_CURVES
 from charted.utils.line_renderer import LineRenderer
-from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+from charted.utils.types import (
+    Labels,
+    ReferenceLineDict,
+    SeriesStyleConfig,
+    Vector,
+    Vector2D,
+)
 
 if TYPE_CHECKING:
+    from charted.charts.chart import _Annotation
     from charted.utils.line_renderer import _LineHost
 
 
@@ -93,11 +100,11 @@ class LineChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list[Any] | None = None,
+        annotations: list[_Annotation] | None = None,
         curve: str = "linear",
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict[str, Any]] | None = None,
+        reference_lines: list[ReferenceLineDict] | None = None,
         colors: list[str] | None = None,
         legend: str = "none",
         dash_cycle: list[str] | bool | None = None,

--- a/charted/charts/pie.py
+++ b/charted/charts/pie.py
@@ -11,7 +11,13 @@ from charted.themes.core import Theme
 from charted.utils.colors import complementary_color, get_contrast_color
 from charted.utils.defaults import DEFAULT_COLORS
 from charted.utils.rendering import create_pie_legend
-from charted.utils.types import Labels, SeriesStyleConfig, Vector, Vector2D
+from charted.utils.types import (
+    Labels,
+    SeriesStyleConfig,
+    ValueLabelOptions,
+    Vector,
+    Vector2D,
+)
 
 
 class _PieSlice(TypedDict):
@@ -359,7 +365,10 @@ class PieChart(Chart):
                 from charted.utils.value_format import format_value
 
                 cfg = self._pie_value_labels
-                opts = {k: v for k, v in cfg.items() if k != "format"}
+                opts = cast(
+                    "ValueLabelOptions",
+                    {k: v for k, v in cfg.items() if k != "format"},
+                )
                 fmt = cfg["format"]
                 # For percent format, label the slice's share of the whole.
                 raw = (value / total) if fmt == "percent" else value

--- a/charted/charts/polar_area.py
+++ b/charted/charts/polar_area.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, cast
+from typing import cast
 
 from charted.charts.pie import PieChart
 from charted.config import get_pie_label_font_size
@@ -371,7 +371,7 @@ class PolarAreaChart(PieChart):
                 )
             )
 
-    def to_config(self) -> dict[str, Any]:
+    def to_config(self) -> dict[str, object]:
         cfg = super().to_config()
         cfg["data"] = list(self._pie_data)
         cfg["labels"] = [

--- a/charted/charts/scatter.py
+++ b/charted/charts/scatter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from charted.charts.chart import Chart
 from charted.constants import (
@@ -14,10 +14,14 @@ from charted.html.element import Circle, Element, G, Path, Rect, Text
 from charted.themes.core import Theme
 from charted.utils.types import (
     PointStyleConfig,
+    ReferenceLineDict,
     SeriesStyleConfig,
     Vector,
     Vector2D,
 )
+
+if TYPE_CHECKING:
+    from charted.charts.chart import _Annotation
 
 
 class _PlacedLabel(TypedDict):
@@ -148,7 +152,7 @@ class ScatterChart(Chart):
         y_label: str | None = None,
         h_lines: list[float] | None = None,
         v_lines: list[float] | None = None,
-        annotations: list[object] | None = None,
+        annotations: list[_Annotation] | None = None,
         quadrant_labels: list[str] | None = None,
         quadrant_label_inset: float = 12.0,
         quadrant_label_backplate: bool = False,
@@ -156,7 +160,7 @@ class ScatterChart(Chart):
         legend: str = "none",
         x_scale: object | None = None,
         y_scale: object | None = None,
-        reference_lines: list[dict[str, object]] | None = None,
+        reference_lines: list[ReferenceLineDict] | None = None,
         colors: list[str] | None = None,
         x_range: tuple[float, float] | None = None,
         y_range: tuple[float, float] | None = None,

--- a/charted/cli/create.py
+++ b/charted/cli/create.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 from ..charts import (
     AreaChart,
@@ -22,6 +22,7 @@ from ..charts import (
     RadarChart,
     ScatterChart,
 )
+from ..utils.types import ChartDataDict, ComboSeriesDict
 
 CHART_TYPES = {
     "area": AreaChart,
@@ -41,7 +42,7 @@ CHART_TYPES = {
 }
 
 
-def load_data(data_path: str, transpose: bool = False) -> dict[str, Any]:
+def load_data(data_path: str, transpose: bool = False) -> ChartDataDict:
     """Load data from CSV or JSON file.
 
     Args:
@@ -61,7 +62,7 @@ def load_data(data_path: str, transpose: bool = False) -> dict[str, Any]:
 
     if suffix == ".json":
         with open(path) as f:
-            return cast("dict[str, Any]", json.load(f))
+            return cast("ChartDataDict", json.load(f))
     elif suffix == ".csv":
         return _parse_csv(path, transpose=transpose)
     else:
@@ -76,7 +77,7 @@ def _to_number(value: str) -> float | str:
         return value
 
 
-def _parse_csv(path: Path, transpose: bool = False) -> dict[str, Any]:
+def _parse_csv(path: Path, transpose: bool = False) -> ChartDataDict:
     """Parse a CSV file into a chart-compatible data dict.
 
     Default layout (``transpose=False``): the first column is the x-axis
@@ -114,7 +115,7 @@ def _parse_csv(path: Path, transpose: bool = False) -> dict[str, Any]:
         return {"data": data_values, "labels": labels}
 
 
-def _parse_csv_transposed(path: Path) -> dict[str, Any]:
+def _parse_csv_transposed(path: Path) -> ChartDataDict:
     """Parse a wide / series-per-row CSV (see _parse_csv for the layout)."""
     import csv
 
@@ -136,7 +137,7 @@ def _parse_csv_transposed(path: Path) -> dict[str, Any]:
         series_names.append(row[0])
         data_values.append([_to_number(cell) for cell in row[1:]])
 
-    result: dict[str, Any] = {"labels": labels, "series_names": series_names}
+    result: ChartDataDict = {"labels": labels, "series_names": series_names}
     if len(data_values) == 1:
         result["data"] = data_values[0]
     else:
@@ -144,7 +145,7 @@ def _parse_csv_transposed(path: Path) -> dict[str, Any]:
     return result
 
 
-def _build_combo_kwargs(data: dict[str, Any]) -> dict[str, Any]:
+def _build_combo_kwargs(data: ChartDataDict) -> ChartDataDict:
     """Map loaded data into ComboChart's series-based keyword arguments.
 
     Accepts either a dict that already carries a ``series`` list (passed
@@ -166,14 +167,17 @@ def _build_combo_kwargs(data: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("no data provided for combo chart")
 
     # Normalise to a list of series (list of lists).
-    if raw and not isinstance(raw[0], list):
+    columns: list[object]
+    if isinstance(raw, list) and raw and not isinstance(raw[0], list):
         columns = [raw]
     else:
-        columns = list(raw)
+        columns = list(raw) if isinstance(raw, list) else []
 
     # Drop non-numeric columns (e.g. a stray label column read as data).
     numeric_columns = [
-        col for col in columns if all(isinstance(v, (int, float)) for v in col)
+        col
+        for col in columns
+        if isinstance(col, list) and all(isinstance(v, (int, float)) for v in col)
     ]
     if len(numeric_columns) < 2:
         raise ValueError(
@@ -181,7 +185,7 @@ def _build_combo_kwargs(data: dict[str, Any]) -> dict[str, Any]:
             f"got {len(numeric_columns)}"
         )
 
-    series = []
+    series: list[ComboSeriesDict] = []
     for i, col in enumerate(numeric_columns):
         series.append(
             {
@@ -191,7 +195,7 @@ def _build_combo_kwargs(data: dict[str, Any]) -> dict[str, Any]:
             }
         )
 
-    kwargs = {"series": series}
+    kwargs: ChartDataDict = {"series": series}
     if labels is not None:
         kwargs["labels"] = labels
     return kwargs

--- a/charted/config.py
+++ b/charted/config.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 try:
     import tomllib  # type: ignore[import-not-found,unused-ignore]
@@ -22,6 +22,7 @@ from .utils.defaults import (
     DEFAULT_FONT_SIZE,
     DEFAULT_TITLE_FONT_SIZE,
 )
+from .utils.types import ChartedConfig
 
 CONFIG_FILENAMES = [".chartedrc.toml", ".chartedrc", "charted.toml"]
 
@@ -41,9 +42,9 @@ def find_config(start_dir: str | None = None) -> Path | None:
     return None
 
 
-def load_config(config_path: str | Path | None = None) -> dict[str, Any]:
+def load_config(config_path: str | Path | None = None) -> ChartedConfig:
     """Load config from .chartedrc file, returning defaults if not found."""
-    defaults: dict[str, Any] = {
+    defaults: dict[str, object] = {
         "font": DEFAULT_FONT,
         "font_size": DEFAULT_FONT_SIZE,
         "title_font_size": DEFAULT_TITLE_FONT_SIZE,
@@ -62,17 +63,17 @@ def load_config(config_path: str | Path | None = None) -> dict[str, Any]:
         config_path = find_config()
 
     if config_path is None:
-        return defaults
+        return cast("ChartedConfig", defaults)
 
     path = Path(config_path)
     if not path.exists():
-        return defaults
+        return cast("ChartedConfig", defaults)
 
     try:
         with open(path, "rb") as f:
-            loaded = tomllib.load(f)
+            loaded: dict[str, object] = tomllib.load(f)
     except (tomllib.TOMLDecodeError, OSError):
-        return defaults
+        return cast("ChartedConfig", defaults)
 
     # Merge loaded config with defaults
     for key in defaults:
@@ -80,13 +81,14 @@ def load_config(config_path: str | Path | None = None) -> dict[str, Any]:
             defaults[key] = loaded[key]
 
     # Extract [theme] block for new theme API
-    if "theme" in loaded and isinstance(loaded["theme"], dict):
-        defaults["theme_section"] = loaded["theme"]
+    theme_block = loaded.get("theme")
+    if isinstance(theme_block, dict):
+        defaults["theme_section"] = theme_block
 
-    return defaults
+    return cast("ChartedConfig", defaults)
 
 
-def get_chart_theme(config: dict[str, Any], chart_type: str) -> dict[str, Any] | None:
+def get_chart_theme(config: ChartedConfig, chart_type: str) -> dict[str, object] | None:
     """Get chart-type-specific theme overrides.
 
     Args:
@@ -97,11 +99,13 @@ def get_chart_theme(config: dict[str, Any], chart_type: str) -> dict[str, Any] |
         Chart-specific theme overrides or None.
     """
     charts_config = config.get("charts", {})
-    result: dict[str, Any] | None = charts_config.get(chart_type, None)
-    return result
+    result = charts_config.get(chart_type, None)
+    if isinstance(result, dict):
+        return result
+    return None
 
 
-def get_font(config: dict[str, Any] | None = None) -> Font:
+def get_font(config: ChartedConfig | None = None) -> Font:
     """Create a Font instance from config.
 
     Args:
@@ -120,7 +124,7 @@ def get_font(config: dict[str, Any] | None = None) -> Font:
     )
 
 
-def get_title_font(config: dict[str, Any] | None = None) -> Font:
+def get_title_font(config: ChartedConfig | None = None) -> Font:
     """Create a Font instance for titles from config.
 
     Args:
@@ -139,7 +143,7 @@ def get_title_font(config: dict[str, Any] | None = None) -> Font:
     )
 
 
-def get_bar_gap(config: dict[str, Any] | None = None) -> float:
+def get_bar_gap(config: ChartedConfig | None = None) -> float:
     """Get bar gap setting from config.
 
     Args:
@@ -154,7 +158,7 @@ def get_bar_gap(config: dict[str, Any] | None = None) -> float:
     return cast("float", config.get("bar", {}).get("bar_gap", 0.50))
 
 
-def get_column_gap(config: dict[str, Any] | None = None) -> float:
+def get_column_gap(config: ChartedConfig | None = None) -> float:
     """Get column gap setting from config.
 
     Args:
@@ -169,7 +173,7 @@ def get_column_gap(config: dict[str, Any] | None = None) -> float:
     return cast("float", config.get("column", {}).get("column_gap", 0.50))
 
 
-def get_pie_label_font_size(config: dict[str, Any] | None = None) -> int:
+def get_pie_label_font_size(config: ChartedConfig | None = None) -> int:
     """Get pie label font size from config.
 
     Args:

--- a/charted/config.py
+++ b/charted/config.py
@@ -1,12 +1,13 @@
 """Configuration loader for .chartedrc files."""
 
 import os
+import sys
 from pathlib import Path
 from typing import cast
 
-try:
-    import tomllib  # type: ignore[import-not-found,unused-ignore]
-except ImportError:
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
     import tomli as tomllib  # type: ignore[import-not-found]
 
 from .constants import (

--- a/charted/config.py
+++ b/charted/config.py
@@ -5,16 +5,6 @@ import sys
 from pathlib import Path
 from typing import cast
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    try:
-        import tomli as tomllib
-    except ModuleNotFoundError:
-        # Keep the library importable on Python < 3.11 without tomli; only
-        # reading a TOML config actually needs it (see load_config).
-        tomllib = None
-
 from .constants import (
     DEFAULT_CHART_HEIGHT,
     DEFAULT_CHART_WIDTH,
@@ -29,6 +19,29 @@ from .utils.defaults import (
     DEFAULT_TITLE_FONT_SIZE,
 )
 from .utils.types import ChartedConfig
+
+
+def _read_toml(path: Path) -> dict[str, object]:
+    """Parse a TOML file, importing the parser lazily.
+
+    tomllib is stdlib on 3.11+. On older Pythons it needs the optional tomli
+    package, so the import is deferred to here (the only place that needs it):
+    the library stays importable on 3.10 without tomli, and a missing parser
+    surfaces as a clear, actionable error only when a TOML config is read.
+    """
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        try:
+            import tomli as tomllib
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                f"Reading the TOML config at {path} requires the 'tomli' package "
+                "on Python < 3.11. Install it with `pip install tomli`, or use "
+                "Python 3.11+."
+            ) from exc
+    with open(path, "rb") as f:
+        return cast("dict[str, object]", tomllib.load(f))
 
 CONFIG_FILENAMES = [".chartedrc.toml", ".chartedrc", "charted.toml"]
 
@@ -75,16 +88,12 @@ def load_config(config_path: str | Path | None = None) -> ChartedConfig:
     if not path.exists():
         return cast("ChartedConfig", defaults)
 
-    if tomllib is None:
-        raise RuntimeError(
-            f"Reading the TOML config at {path} requires the 'tomli' package on "
-            "Python < 3.11. Install it with `pip install tomli`, or use Python 3.11+."
-        )
-
     try:
-        with open(path, "rb") as f:
-            loaded: dict[str, object] = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, OSError):
+        loaded: dict[str, object] = _read_toml(path)
+    except (OSError, ValueError):
+        # ValueError covers tomllib.TOMLDecodeError (a ValueError subclass). A
+        # missing-tomli RuntimeError is intentionally NOT caught: it should
+        # surface to the caller.
         return cast("ChartedConfig", defaults)
 
     # Merge loaded config with defaults

--- a/charted/config.py
+++ b/charted/config.py
@@ -8,7 +8,7 @@ from typing import cast
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib  # type: ignore[import-not-found]
+    import tomli as tomllib
 
 from .constants import (
     DEFAULT_CHART_HEIGHT,

--- a/charted/config.py
+++ b/charted/config.py
@@ -8,7 +8,12 @@ from typing import cast
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        # Keep the library importable on Python < 3.11 without tomli; only
+        # reading a TOML config actually needs it (see load_config).
+        tomllib = None
 
 from .constants import (
     DEFAULT_CHART_HEIGHT,
@@ -69,6 +74,12 @@ def load_config(config_path: str | Path | None = None) -> ChartedConfig:
     path = Path(config_path)
     if not path.exists():
         return cast("ChartedConfig", defaults)
+
+    if tomllib is None:
+        raise RuntimeError(
+            f"Reading the TOML config at {path} requires the 'tomli' package on "
+            "Python < 3.11. Install it with `pip install tomli`, or use Python 3.11+."
+        )
 
     try:
         with open(path, "rb") as f:

--- a/charted/fonts/tkinter.py
+++ b/charted/fonts/tkinter.py
@@ -4,7 +4,7 @@ Provides TextMeasurer for measuring text dimensions using tkinter.
 Gracefully handles environments where tkinter is not available.
 """
 
-from typing import Any, cast
+from typing import Literal, cast
 
 try:
     import tkinter as tk
@@ -42,10 +42,14 @@ class TextMeasurer:
         family: str = "Helvetica",
         size: int = 12,
         weight: str = "normal",
-    ) -> tuple[float, float]:
+    ) -> tuple[int, int]:
         if self.root is None:
             raise RuntimeError("TextMeasurer must be used within a 'with' statement")
-        font = tkfont.Font(family=family, size=size, weight=cast("Any", weight))
+        font = tkfont.Font(
+            family=family,
+            size=size,
+            weight=cast('Literal["normal", "bold"]', weight),
+        )
 
         canvas = tk.Canvas(self.root)
         text_id = canvas.create_text(0, 0, text=text, font=font, anchor="nw")
@@ -54,7 +58,7 @@ class TextMeasurer:
 
         return font.measure(text), height
 
-    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+    def __exit__(self, *args: object, **kwargs: object) -> None:
         if self.root:
             self.root.destroy()
             self.root = None

--- a/charted/fonts/utils.py
+++ b/charted/fonts/utils.py
@@ -1,9 +1,8 @@
 import json
 import os
-from typing import Any
 
 from charted.utils.defaults import BASE_DEFINITIONS_DIR
-from charted.utils.helpers import nested_defaultdict
+from charted.utils.types import CharMetrics
 
 
 def create_font_definition(
@@ -14,14 +13,16 @@ def create_font_definition(
     from charted.fonts.tkinter import TextMeasurer
 
     chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`~!@#$%^&*()-_=+[]{}|;:\'",.<>?/\\"£¥€©®™✓•¶§±æøåßüñ¿¡çµ½¼¾×÷°ƒ∆≈∞Ω≠≤≥¬√πø∆¥¤¢₱₩₹₽℅ℓ№©℗℠℮∞‽ '
-    lookup: Any = nested_defaultdict()
+    lookup: dict[int, dict[int, CharMetrics]] = {}
 
     with TextMeasurer() as tm:
         for font_size in range(min_font_size, max_font_size):
             for char in chars:
                 w, h = tm.measure_text(char, family=font, size=font_size)
-                lookup[font_size][ord(char)]["width"] = w
-                lookup[font_size][ord(char)]["height"] = h
+                lookup.setdefault(font_size, {})[ord(char)] = {
+                    "width": w,
+                    "height": h,
+                }
 
         with open(os.path.join(BASE_DEFINITIONS_DIR, f"{font}.json"), "w") as dst:
             dst.write(json.dumps(lookup, indent=2))

--- a/charted/fonts/wrapper.py
+++ b/charted/fonts/wrapper.py
@@ -3,9 +3,10 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 from charted.utils.defaults import BASE_DEFINITIONS_DIR, DEFAULT_FONT, DEFAULT_FONT_SIZE
+from charted.utils.types import FontDefinition
 
 
 class Font:
@@ -31,7 +32,7 @@ class Font:
         # Load font definition file
         self.definitions = self._load_definitions()
 
-    def _load_definitions(self) -> dict[str, dict[str, Any]]:
+    def _load_definitions(self) -> FontDefinition:
         """Load font definitions from JSON file."""
         font_path = Path(self.definitions_dir) / f"{self.family}.json"
 
@@ -46,7 +47,7 @@ class Font:
 
         try:
             with open(font_path, "r") as f:
-                return cast("dict[str, dict[str, Any]]", json.load(f))
+                return cast("FontDefinition", json.load(f))
         except json.JSONDecodeError as e:
             import warnings
 
@@ -58,7 +59,7 @@ class Font:
             warnings.warn(f"Failed to load font file '{font_path}': {e}")
             return {}
 
-    def _load_definitions_fallback(self, fallback: str) -> dict[str, dict[str, Any]]:
+    def _load_definitions_fallback(self, fallback: str) -> FontDefinition:
         """Load fallback font definitions."""
         fallback_path = Path(self.definitions_dir) / f"{fallback}.json"
 
@@ -67,7 +68,7 @@ class Font:
 
         try:
             with open(fallback_path, "r") as f:
-                return cast("dict[str, dict[str, Any]]", json.load(f))
+                return cast("FontDefinition", json.load(f))
         except (json.JSONDecodeError, IOError):
             return {}
 
@@ -127,7 +128,7 @@ class Font:
         char_code = ord(char)
 
         if str(char_code) in definitions:
-            return cast("float", definitions[str(char_code)].get("width", 5))
+            return definitions[str(char_code)].get("width", 5)
         return 5  # Default width for unknown chars
 
     @classmethod

--- a/charted/themes/core.py
+++ b/charted/themes/core.py
@@ -1,9 +1,10 @@
 """Core Theme dataclass and ColorPalette for charted."""
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from functools import wraps
-from typing import Any, Optional
+from typing import Optional, cast
 
 from charted.constants import REFERENCE_LINE_WIDTH
 
@@ -702,14 +703,14 @@ def _wrap_theme_init() -> None:
     signature = inspect.signature(original_init)
 
     @wraps(original_init)
-    def __init__(self: Theme, *args: Any, **kwargs: Any) -> None:  # noqa: N807
+    def __init__(self: Theme, *args: object, **kwargs: object) -> None:  # noqa: N807
         # The tracking marker leaks into ``vars(theme)``; tolerate (and honour)
         # it when a caller round-trips a theme via ``Theme(**vars(theme))`` so
         # the provided-set survives the copy and isn't passed to the dataclass
         # constructor (which would reject the unknown keyword).
         preset = kwargs.pop("_explicitly_set", None)
         if preset is not None:
-            provided = frozenset(preset)
+            provided = frozenset(cast("Iterable[str]", preset))
         else:
             try:
                 bound = signature.bind(self, *args, **kwargs)
@@ -718,7 +719,10 @@ def _wrap_theme_init() -> None:
                 )
             except TypeError:
                 provided = frozenset()
-        original_init(self, *args, **kwargs)
+        # Dynamic passthrough to the real dataclass ``__init__``; ``*args`` /
+        # ``**kwargs`` carry heterogeneous per-field values that cannot be
+        # statically matched to the generated typed parameters.
+        original_init(self, *args, **kwargs)  # type: ignore[arg-type]
         object.__setattr__(self, "_explicitly_set", provided)
 
     Theme.__init__ = __init__  # type: ignore[method-assign]

--- a/charted/utils/color_manager.py
+++ b/charted/utils/color_manager.py
@@ -4,9 +4,12 @@ This module provides a ColorManager class for automatic color cycling,
 palette expansion, and contrast validation.
 """
 
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from charted.utils.colors import calculate_contrast_ratio
+
+if TYPE_CHECKING:
+    from charted.themes.core import Theme
 
 
 class ColorManager:
@@ -106,7 +109,7 @@ class ColorManager:
         ratio = calculate_contrast_ratio(foreground, background)
         return ratio
 
-    def validate_theme(self, theme: Any) -> List[str]:
+    def validate_theme(self, theme: "Theme") -> List[str]:
         """Validate theme colors for WCAG contrast compliance.
 
         Args:

--- a/charted/utils/config_schema.py
+++ b/charted/utils/config_schema.py
@@ -4,10 +4,12 @@ This module provides JSON schema definitions and validation logic
 for .chartedrc.toml configuration files with theme support.
 """
 
-from typing import Any, Dict, List
+from collections.abc import Mapping
+
+from .types import JSONSchema
 
 # Theme property schema definition
-THEME_SCHEMA: Dict[str, Any] = {
+THEME_SCHEMA: JSONSchema = {
     "type": "object",
     "properties": {
         "colors": {
@@ -95,7 +97,7 @@ THEME_SCHEMA: Dict[str, Any] = {
 }
 
 # Chart-type specific theme override schema
-CHART_THEME_OVERRIDES: Dict[str, Any] = {
+CHART_THEME_OVERRIDES: JSONSchema = {
     "type": "object",
     "properties": {
         "theme": THEME_SCHEMA,
@@ -104,7 +106,7 @@ CHART_THEME_OVERRIDES: Dict[str, Any] = {
 }
 
 
-def validate_theme_dict(theme_dict: Dict[str, Any]) -> tuple[bool, List[str]]:
+def validate_theme_dict(theme_dict: Mapping[str, object]) -> tuple[bool, list[str]]:
     """Validate a theme dictionary against the schema.
 
     Args:
@@ -169,7 +171,7 @@ def validate_theme_dict(theme_dict: Dict[str, Any]) -> tuple[bool, List[str]]:
     return len(errors) == 0, errors
 
 
-def validate_config(config: Dict[str, Any]) -> tuple[bool, List[str]]:
+def validate_config(config: Mapping[str, object]) -> tuple[bool, list[str]]:
     """Validate entire config dictionary.
 
     Args:
@@ -181,18 +183,20 @@ def validate_config(config: Dict[str, Any]) -> tuple[bool, List[str]]:
     errors = []
 
     # Validate theme section if present
-    if "theme_section" in config and config["theme_section"]:
-        is_valid, theme_errors = validate_theme_dict(config["theme_section"])
+    theme_section = config.get("theme_section")
+    if isinstance(theme_section, dict):
+        is_valid, theme_errors = validate_theme_dict(theme_section)
         if not is_valid:
             errors.extend([f"[theme] {e}" for e in theme_errors])
 
     # Validate chart-specific themes
     chart_types = ["bar", "column", "line", "pie", "scatter", "radar"]
     for chart_type in chart_types:
-        if chart_type in config and isinstance(config[chart_type], dict):
-            chart_config = config[chart_type]
-            if "theme" in chart_config:
-                is_valid, theme_errors = validate_theme_dict(chart_config["theme"])
+        chart_config = config.get(chart_type)
+        if isinstance(chart_config, dict):
+            theme = chart_config.get("theme")
+            if isinstance(theme, dict):
+                is_valid, theme_errors = validate_theme_dict(theme)
                 if not is_valid:
                     errors.extend([f"[{chart_type}.theme] {e}" for e in theme_errors])
 

--- a/charted/utils/data_input.py
+++ b/charted/utils/data_input.py
@@ -6,13 +6,33 @@ the best chart type based on data shape.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Protocol, cast
 
 from charted.constants import DEFAULT_CHART_HEIGHT, DEFAULT_CHART_WIDTH
 
+if TYPE_CHECKING:
+    from charted.charts import Chart
+
+
+class _ChartFactory(Protocol):
+    """Callable producing a chart from keyword-only constructor arguments."""
+
+    def __call__(self, **kwargs: object) -> Chart: ...
+
+
+def _construct(chart_cls: type[Chart], **kwargs: object) -> Chart:
+    """Instantiate a chart class with dynamically-built keyword arguments.
+
+    The keyword arguments are assembled at runtime from heterogeneous user
+    data, so they are typed as ``object`` and the concrete subclass signature
+    cannot be checked statically. The cast localises that one unavoidable
+    dynamic call.
+    """
+    return cast("_ChartFactory", chart_cls)(**kwargs)
+
 
 def auto_size(
-    data: Any, width: float | None = None, height: float | None = None
+    data: object, width: float | None = None, height: float | None = None
 ) -> tuple[float, float]:
     """Calculate canvas dimensions based on data size.
 
@@ -57,7 +77,7 @@ def auto_size(
     return DEFAULT_CHART_WIDTH, DEFAULT_CHART_HEIGHT
 
 
-def from_dict(data: dict[str, Any], **kwargs: Any) -> Any:
+def from_dict(data: dict[str, object], **kwargs: object) -> Chart:
     """Create a chart from a dict-based config.
 
     Expects a dict with at least ``data`` key containing the raw data,
@@ -88,8 +108,8 @@ def from_dict(data: dict[str, Any], **kwargs: Any) -> Any:
     raw = cfg.pop("data", None)
     cls_map = _CHART_CLASSES()
 
-    chart_cls: Any
-    if chart_type and chart_type in cls_map:
+    chart_cls: type[Chart]
+    if isinstance(chart_type, str) and chart_type in cls_map:
         chart_cls = cls_map[chart_type]
     else:
         chart_cls = cls_map["BarChart"]
@@ -121,10 +141,10 @@ def from_dict(data: dict[str, Any], **kwargs: Any) -> Any:
     sig = inspect.signature(chart_cls.__init__)
     valid_params = set(sig.parameters.keys()) - {"self"}
     filtered_cfg = {k: v for k, v in cfg.items() if k in valid_params}
-    return chart_cls(**filtered_cfg)
+    return _construct(chart_cls, **filtered_cfg)
 
 
-def from_dataframe(df: Any, **kwargs: Any) -> Any:
+def from_dataframe(df: object, **kwargs: object) -> Chart:
     """Create a chart from a pandas DataFrame.
 
     Accepts an optional ``pandas.DataFrame``. If pandas is not installed,
@@ -154,8 +174,8 @@ def from_dataframe(df: Any, **kwargs: Any) -> Any:
     chart_type = kwargs.pop("chart_type", None)
     cls_map = _CHART_CLASSES()
 
-    chart_cls: Any
-    if chart_type and chart_type in cls_map:
+    chart_cls: type[Chart]
+    if isinstance(chart_type, str) and chart_type in cls_map:
         chart_cls = cls_map[chart_type]
     else:
         chart_cls = cls_map["BarChart"]
@@ -179,8 +199,12 @@ def from_dataframe(df: Any, **kwargs: Any) -> Any:
         else:
             x_labels = list(range(len(df)))
 
-        return chart_cls(
-            y_data=y_data, x_labels=x_labels, series_names=series_names, **kwargs
+        return _construct(
+            chart_cls,
+            y_data=y_data,
+            x_labels=x_labels,
+            series_names=series_names,
+            **kwargs,
         )
 
     # Dict fallback: column-name -> list
@@ -201,7 +225,7 @@ def from_dataframe(df: Any, **kwargs: Any) -> Any:
 
         sig = inspect.signature(chart_cls.__init__)
         valid_params = set(sig.parameters.keys()) - {"self"}
-        chart_kwargs = {}
+        chart_kwargs: dict[str, object] = {}
         # Map x_labels -> labels for classes that expect labels
         labels_param = "labels" if "labels" in valid_params else "x_labels"
         if labels_param in valid_params:
@@ -215,7 +239,7 @@ def from_dataframe(df: Any, **kwargs: Any) -> Any:
         for k, v in kwargs.items():
             if k in valid_params:
                 chart_kwargs[k] = v
-        return chart_cls(**chart_kwargs)
+        return _construct(chart_cls, **chart_kwargs)
 
     raise TypeError(
         f"Expected a pandas DataFrame or dict, got {type(df).__name__}. "
@@ -223,7 +247,7 @@ def from_dataframe(df: Any, **kwargs: Any) -> Any:
     )
 
 
-def auto(data: Any, **kwargs: Any) -> Any:
+def auto(data: object, **kwargs: object) -> Chart:
     """Auto-detect chart type from data shape and create the chart.
 
     Heuristic:
@@ -246,11 +270,17 @@ def auto(data: Any, **kwargs: Any) -> Any:
     from charted.charts import _CHART_CLASSES
 
     cls_map = _CHART_CLASSES()
-    chart_cls: Any
+    chart_cls: type[Chart]
 
     # Auto-size if width/height not specified
     if "width" not in kwargs and "height" not in kwargs:
-        w, h = auto_size(data, kwargs.get("width"), kwargs.get("height"))
+        kw_width = kwargs.get("width")
+        kw_height = kwargs.get("height")
+        w, h = auto_size(
+            data,
+            kw_width if isinstance(kw_width, (int, float)) else None,
+            kw_height if isinstance(kw_height, (int, float)) else None,
+        )
         kwargs.setdefault("width", w)
         kwargs.setdefault("height", h)
 
@@ -258,14 +288,18 @@ def auto(data: Any, **kwargs: Any) -> Any:
     # equal-length rows [x, y, sizes], signals a third numeric dimension that
     # maps to marker radius -> BubbleChart.
     if "sizes" in kwargs and kwargs["sizes"] is not None:
-        chart_cls = cls_map.get("BubbleChart")
-        assert chart_cls is not None
+        chart_cls = cls_map["BubbleChart"]
+        x: object
+        y: object
         if isinstance(data, list) and data and isinstance(data[0], list):
             x, y = data[0], data[1]
-        else:
+        elif isinstance(data, list):
             x = list(range(len(data)))
             y = data
-        return chart_cls(x_data=x, y_data=y, **kwargs)
+        else:
+            x = []
+            y = data
+        return _construct(chart_cls, x_data=x, y_data=y, **kwargs)
 
     # Detect shape
     if isinstance(data, list):
@@ -276,11 +310,10 @@ def auto(data: Any, **kwargs: Any) -> Any:
         if not isinstance(data[0], list):
             # Small sets → PieChart, otherwise BarChart
             if len(data) <= 6:
-                chart_cls = cls_map.get("PieChart")
+                chart_cls = cls_map["PieChart"]
             else:
-                chart_cls = cls_map.get("BarChart")
-            assert chart_cls is not None
-            return chart_cls(data=data, **kwargs)
+                chart_cls = cls_map["BarChart"]
+            return _construct(chart_cls, data=data, **kwargs)
 
         # 2D data
         n_rows = len(data)
@@ -288,19 +321,16 @@ def auto(data: Any, **kwargs: Any) -> Any:
 
         if n_rows <= 3 and n_cols > 3:
             # Few rows, many columns: could be grouped bar or line
-            chart_cls = cls_map.get("ColumnChart")
-            assert chart_cls is not None
-            return chart_cls(data=data, **kwargs)
+            chart_cls = cls_map["ColumnChart"]
+            return _construct(chart_cls, data=data, **kwargs)
         elif n_rows > 3 and n_cols <= 6:
             # Many rows, few columns: line chart
-            chart_cls = cls_map.get("LineChart")
-            assert chart_cls is not None
-            return chart_cls(data=data, **kwargs)
+            chart_cls = cls_map["LineChart"]
+            return _construct(chart_cls, data=data, **kwargs)
         else:
             # Square-ish matrix: heatmap
-            chart_cls = cls_map.get("HeatmapChart")
-            assert chart_cls is not None
-            return chart_cls(data=data, **kwargs)
+            chart_cls = cls_map["HeatmapChart"]
+            return _construct(chart_cls, data=data, **kwargs)
 
     if isinstance(data, dict):
         # Dict of column -> list: use from_dataframe

--- a/charted/utils/rendering.py
+++ b/charted/utils/rendering.py
@@ -3,7 +3,7 @@
 Extracted from Chart class to reduce coupling and improve testability.
 """
 
-from typing import Any
+from typing import cast
 from urllib.parse import quote
 
 from charted.html.element import G, Path, Rect, Text
@@ -247,7 +247,7 @@ def create_legend_entry(
 def create_legend(
     series_names: list[str],
     colors: list[str],
-    theme_config: "Theme | dict[str, Any]",
+    theme_config: "Theme | dict[str, object]",
     plot_left: float,
     plot_right: float,
     top_padding: float,
@@ -279,12 +279,12 @@ def create_legend(
         position = getattr(theme_config, "legend_position", "topright")
         background_color = getattr(theme_config, "background_color", "#ffffff")
     else:
-        font_size = theme_config.get("font_size", 12)
-        legend_padding = theme_config.get("legend_padding", 0.15)
-        font_family = theme_config.get("font_family", "Arial")
-        font_color = theme_config.get("font_color", "#444444")
-        position = theme_config.get("position", "topright")
-        background_color = theme_config.get("background_color", "#ffffff")
+        font_size = cast("float", theme_config.get("font_size", 12))
+        legend_padding = cast("float", theme_config.get("legend_padding", 0.15))
+        font_family = cast("str", theme_config.get("font_family", "Arial"))
+        font_color = cast("str", theme_config.get("font_color", "#444444"))
+        position = cast("str", theme_config.get("position", "topright"))
+        background_color = cast("str", theme_config.get("background_color", "#ffffff"))
 
     # Derive legend-specific colors from the background
     stroke_color = _derive_legend_stroke(background_color)
@@ -358,7 +358,7 @@ def create_legend(
 def create_pie_legend(
     series_names: list[str],
     colors: list[str],
-    theme_config: "Theme | dict[str, Any]",
+    theme_config: "Theme | dict[str, object]",
     chart_width: float,
     chart_height: float,
 ) -> G | None:
@@ -388,10 +388,10 @@ def create_pie_legend(
         font_color = getattr(theme_config, "legend_font_color", "#444444")
         background_color = getattr(theme_config, "background_color", "#ffffff")
     else:
-        font_size = theme_config.get("font_size", 12)
-        font_family = theme_config.get("font_family", "Arial")
-        font_color = theme_config.get("font_color", "#444444")
-        background_color = theme_config.get("background_color", "#ffffff")
+        font_size = cast("float", theme_config.get("font_size", 12))
+        font_family = cast("str", theme_config.get("font_family", "Arial"))
+        font_color = cast("str", theme_config.get("font_color", "#444444"))
+        background_color = cast("str", theme_config.get("background_color", "#ffffff"))
 
     # Derive legend-specific colors from the background
     legend_bg = _derive_legend_background(background_color)

--- a/charted/utils/theme_manager.py
+++ b/charted/utils/theme_manager.py
@@ -4,7 +4,7 @@ Extracted from Chart class to reduce coupling and improve testability.
 This module encapsulates all theme loading and merging logic.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from charted.themes.core import Theme
@@ -97,7 +97,7 @@ def _dict_to_theme(data: dict[str, object]) -> "Theme":
     from charted.themes.core import Theme
 
     # Map dict keys to Theme fields - only allow known fields
-    theme_data: dict[str, Any] = {}
+    theme_data: dict[str, object] = {}
     theme_fields = {f.name for f in fields(Theme)}
 
     for key, value in data.items():
@@ -108,4 +108,7 @@ def _dict_to_theme(data: dict[str, object]) -> "Theme":
                 f"Unknown theme field '{key}'. Valid fields: {sorted(theme_fields)}"
             )
 
-    return Theme(**theme_data)
+    # ``theme_data`` is filtered above to only Theme field names, but the values
+    # are heterogeneous (str/int/float/bool/list per field), so the splat cannot
+    # be statically matched to each typed parameter.
+    return Theme(**theme_data)  # type: ignore[arg-type]

--- a/charted/utils/types.py
+++ b/charted/utils/types.py
@@ -114,6 +114,23 @@ class PointStyleConfig(TypedDict, total=False):
     opacity: float | None
 
 
+class CharMetrics(TypedDict):
+    """Width and height of a single glyph at a given font size.
+
+    The generator (:func:`charted.fonts.utils.create_font_definition`) writes
+    integer pixel metrics from tkinter, so every definition file holds ints.
+    """
+
+    width: int
+    height: int
+
+
+# A loaded font-definition JSON file (``charted/fonts/definitions/*.json``).
+# Outer key is the font size as a string, inner key the character code as a
+# string, mapping to that glyph's measured metrics.
+FontDefinition = dict[str, dict[str, CharMetrics]]
+
+
 Labels = list[str]
 
 Vector = list[float]

--- a/charted/utils/types.py
+++ b/charted/utils/types.py
@@ -55,6 +55,50 @@ class SeriesStyleConfig(TypedDict, total=False):
     show_markers: bool | None
 
 
+class ReferenceLineDict(TypedDict, total=False):
+    """One entry of the ``reference_lines`` convenience API.
+
+    ``value`` is required in practice (validated by the chart); ``axis``
+    defaults to ``"y"`` and ``label`` to ``None`` during normalisation.
+    """
+
+    value: float
+    axis: str  # "x" | "y"
+    label: str | None
+
+
+class ValueLabelOptions(TypedDict, total=False):
+    """Keyword options forwarded to ``charted.utils.value_format.format_value``.
+
+    Mirrors that function's keyword-only parameters so the resolved value-label
+    options can be splatted into it with full type checking. The ``format`` key
+    is handled separately and is not part of this options mapping.
+    """
+
+    decimals: int | None
+    prefix: str
+    suffix: str
+    currency_symbol: str
+    thousands_sep: str
+    percent_scale: bool
+
+
+class ValueLabelConfig(TypedDict, total=False):
+    """Normalised ``value_labels`` config from ``Chart._normalize_value_labels``.
+
+    ``format`` selects the formatter; the remaining keys are forwarded to
+    ``format_value`` (see :class:`ValueLabelOptions`).
+    """
+
+    format: str
+    decimals: int | None
+    prefix: str
+    suffix: str
+    currency_symbol: str
+    thousands_sep: str
+    percent_scale: bool
+
+
 class PointStyleConfig(TypedDict, total=False):
     """Per-point marker styling overrides for scatter charts.
 

--- a/charted/utils/types.py
+++ b/charted/utils/types.py
@@ -4,6 +4,41 @@ from typing import NamedTuple, TypedDict
 # Re-export exceptions from exceptions.py for backward compatibility
 
 
+# A JSON-schema definition fragment. JSON schemas are recursive objects whose
+# values are themselves schemas, primitives, or lists of either; ``object`` is
+# the precise type for these heterogeneous leaves.
+JSONSchema = dict[str, object]
+
+
+class ChartedConfig(TypedDict, total=False):
+    """Parsed ``.chartedrc`` configuration.
+
+    Produced by :func:`charted.config.load_config`. Every key carries a default
+    so consumers can ``.get`` safely; ``total=False`` reflects that a loaded TOML
+    file may omit any of them.
+    """
+
+    font: str
+    font_size: int
+    title_font_size: int
+    colors: list[str]
+    width: float
+    height: float
+    theme: object | None
+    charts: dict[str, object]
+    pie: dict[str, object]
+    bar: dict[str, object]
+    column: dict[str, object]
+    theme_section: dict[str, object]
+
+
+# Data dict produced by the CLI loaders (``load_data`` / ``_parse_csv``) and the
+# dict-config import path. Keys map directly onto chart constructor parameters,
+# so the values are heterogeneous (raw vectors, labels, series dicts, scalars).
+# ``object`` keeps it type-safe while permitting arbitrary constructor kwargs.
+ChartDataDict = dict[str, object]
+
+
 class SeriesStyleConfig(TypedDict, total=False):
     """Per-series styling overrides."""
 
@@ -39,6 +74,20 @@ Labels = list[str]
 
 Vector = list[float]
 Vector2D = list[Vector]
+
+
+class ComboSeriesDict(TypedDict, total=False):
+    """One series entry for a combo (mixed bar/line/area) chart.
+
+    ``data`` is the only field a caller must supply; ``type`` defaults to
+    ``"line"``, ``axis`` to ``"primary"`` and ``name`` to ``None`` during
+    normalisation inside :class:`charted.charts.combo.ComboChart`.
+    """
+
+    data: Vector
+    type: str  # "bar" | "column" | "line" | "area"
+    axis: str  # "primary" | "secondary"
+    name: str | None
 
 
 class MeasuredText(NamedTuple):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest>=8.2.1",
     "ipython>=8.24.0",
     "ruff>=0.9.0",
+    "mypy>=1.8",
     "tox>=4.15.1",
     "lxml>=5.0.0",
     "coverage>=7.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,3 +117,4 @@ artifacts = ["charted/fonts/definitions/*.json"]
 python_version = "3.10"
 files = ["charted"]
 strict = true
+disallow_any_explicit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,7 @@ python_version = "3.10"
 files = ["charted"]
 strict = true
 disallow_any_explicit = true
+
+[[tool.mypy.overrides]]
+module = ["tomli"]
+ignore_missing_imports = true


### PR DESCRIPTION
Follow-up to #72. Eliminates every explicit `Any` in the package and turns on `disallow_any_explicit` so it stays gone.

The 80 explicit-Any sites were replaced with precise types: TypedDicts for the config/theme/style/font-definition/reference-line/value-label shapes (in `charted/utils/types.py`), `object` for genuinely opaque values (narrowed with isinstance), and precise casts where a known type could not be inferred. No `dict[str, Any]`, no `cast(Any)`.

Type-only: no runtime behavior change, SVG output byte-identical, `tests/baselines/` untouched (one font-accumulator float-vs-int regression was caught and reverted during the work). `mypy` passes strict + disallow_any_explicit, full suite 1390 passed / 6 skipped.

A handful of `# type: ignore[arg-type]` remain (NOT explicit-any): heterogeneous per-field values splatted into dataclass constructors (Theme(**overrides), dynamic chart-class construction) that the type system cannot statically match. Each is documented at its site.

Note: a CI `mypy` step still needs adding to ci.yml (requires workflow-scope, which the bot lacks).