### PR TITLE
fix: clear install hints for optional extras, refresh SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,45 +1,35 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Security fixes are applied to the current minor release line. Older versions
+do not receive backported fixes; upgrade to the latest 1.1.x release.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
-| < 0.1.0 | :x:                |
+| 1.1.x   | :white_check_mark: |
+| < 1.1.0 | :x:                |
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-We take the security of Charted seriously. If you believe you have found a security vulnerability, please report it to us as described below.
+Please do not open a public GitHub issue for a security vulnerability.
 
-**Please do NOT report security vulnerabilities through public GitHub issues.**
+Report it privately through GitHub's private vulnerability reporting:
 
-Instead, please report them via email at [INSERT SECURITY EMAIL] with the following information:
+1. Go to the repository's Security tab.
+2. Click "Report a vulnerability".
+3. Fill in what you found, how to reproduce it, and the impact.
 
-1. Description of the vulnerability
-2. Steps to reproduce the issue
-3. Potential impact
-4. Suggested fix (if any)
+This opens a private security advisory visible only to the maintainers. If you
+can suggest a fix, include it, but it is not required.
 
-You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+We will review the report, confirm the issue, and work on a fix. Once a fix
+ships, we publish a security advisory on GitHub and credit the reporter unless
+they ask us not to.
 
-After the initial reply to your report, we will send you a more detailed acknowledgment and begin working on a fix. We will keep you informed of the progress toward a fix and full announcement, and may ask for additional information or guidance.
+## Notes for users
 
-### Disclosure Policy
-
-When we release a security fix, we will:
-
-1. Publish a security advisory on GitHub
-2. Update this document with the fix version
-3. Announce the fix in our changelog
-4. Give credit to the reporter (if desired)
-
-### Security Best Practices
-
-When using Charted, please be aware of the following:
-
-- Charted generates SVG files. Always validate SVG output before deploying to production.
-- When loading CSV data, ensure the source is trusted to avoid injection attacks.
-- Keep your dependencies up to date using `uv update`.
+Charted produces SVG output. If you render that SVG in a browser, treat the
+input data the same way you would treat any other untrusted input, since
+attacker-controlled labels or values can end up in the markup. Validate or
+sanitize CSV and other data sources before charting them.

--- a/duckdb_ext/extension.py
+++ b/duckdb_ext/extension.py
@@ -32,11 +32,33 @@ from __future__ import annotations
 import inspect
 import json
 from pathlib import Path
-from typing import Optional
-
-import duckdb
+from types import ModuleType
+from typing import TYPE_CHECKING, Optional
 
 import charted
+
+if TYPE_CHECKING:
+    import duckdb
+
+DUCKDB_MISSING_MESSAGE = (
+    "DuckDB support requires charted[duckdb]. "
+    'Install with: pip install "charted[duckdb]"'
+)
+
+
+def _require_duckdb() -> ModuleType:
+    """Import and return the ``duckdb`` module, or raise a clear error.
+
+    Keeps the optional ``duckdb`` dependency out of import time. When it is not
+    installed, surface a single-line install hint instead of a bare
+    ModuleNotFoundError.
+    """
+    try:
+        import duckdb
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(DUCKDB_MISSING_MESSAGE) from exc
+    return duckdb
+
 
 # Map short names to chart classes
 CHART_TYPES = {
@@ -126,6 +148,7 @@ def _build_chart(
         if labels and len(data) == 1:
             # Group values by label
             from collections import defaultdict
+
             groups = defaultdict(list)
             for i, val in enumerate(data[0]):
                 groups[labels[i]].append(val)
@@ -233,7 +256,9 @@ def charted_query(
     rows = result.fetchall()
 
     labels, data, series_names = _extract_chart_data_from_result(columns, rows)
-    chart = _build_chart(chart_type, labels, data, series_names, title, width, height, theme)
+    chart = _build_chart(
+        chart_type, labels, data, series_names, title, width, height, theme
+    )
 
     Path(output).parent.mkdir(parents=True, exist_ok=True)
     chart.save(output)
@@ -258,7 +283,9 @@ def charted_svg(
     rows = result.fetchall()
 
     labels, data, series_names = _extract_chart_data_from_result(columns, rows)
-    chart = _build_chart(chart_type, labels, data, series_names, title, width, height, theme)
+    chart = _build_chart(
+        chart_type, labels, data, series_names, title, width, height, theme
+    )
     return chart.to_svg()
 
 
@@ -267,7 +294,9 @@ def charted_svg(
 # =============================================================================
 
 
-def _charted_from_arrays_impl(labels_json: str, data_json: str, chart_type: str, title: str, output: str) -> str:
+def _charted_from_arrays_impl(
+    labels_json: str, data_json: str, chart_type: str, title: str, output: str
+) -> str:
     """UDF implementation: takes JSON-encoded labels and data arrays."""
     labels = json.loads(labels_json) if labels_json else None
     data_raw = json.loads(data_json)
@@ -275,7 +304,7 @@ def _charted_from_arrays_impl(labels_json: str, data_json: str, chart_type: str,
     # data_raw is either a single list or list-of-lists
     if data_raw and isinstance(data_raw[0], list):
         data = data_raw
-        series_names = [f"series_{i+1}" for i in range(len(data))]
+        series_names = [f"series_{i + 1}" for i in range(len(data))]
     else:
         data = [data_raw]
         series_names = ["value"]
@@ -290,14 +319,16 @@ def _charted_from_arrays_impl(labels_json: str, data_json: str, chart_type: str,
     return o
 
 
-def _charted_svg_from_arrays_impl(labels_json: str, data_json: str, chart_type: str, title: str) -> str:
+def _charted_svg_from_arrays_impl(
+    labels_json: str, data_json: str, chart_type: str, title: str
+) -> str:
     """UDF implementation: returns SVG string from JSON-encoded arrays."""
     labels = json.loads(labels_json) if labels_json else None
     data_raw = json.loads(data_json)
 
     if data_raw and isinstance(data_raw[0], list):
         data = data_raw
-        series_names = [f"series_{i+1}" for i in range(len(data))]
+        series_names = [f"series_{i + 1}" for i in range(len(data))]
     else:
         data = [data_raw]
         series_names = ["value"]
@@ -322,6 +353,7 @@ def register(con: duckdb.DuckDBPyConnection) -> None:
     For the simpler query-based workflow, use the Python functions:
     charted_query() and charted_svg() directly.
     """
+    duckdb = _require_duckdb()
     VARCHAR = duckdb.sqltype("VARCHAR")
 
     con.create_function(
@@ -357,6 +389,7 @@ def load(db_path: str = ":memory:") -> duckdb.DuckDBPyConnection:
         >>> from charted.duckdb_ext.extension import charted_query
         >>> charted_query(con, 'SELECT x, y FROM data', chart_type='line')
     """
+    duckdb = _require_duckdb()
     con = duckdb.connect(db_path)
     register(con)
     return con

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,10 +1,34 @@
 """MCP Server for the charted SVG chart library."""
 
+from __future__ import annotations
+
+import sys
+
 __version__ = "0.1.0"
 
+MCP_MISSING_MESSAGE = (
+    'MCP support requires charted[mcp]. Install with: pip install "charted[mcp]"'
+)
 
-def main():
-    """Entry point — defers mcp import to runtime."""
-    from mcp_server.server import run
+
+def main() -> None:
+    """Entry point. Defers the mcp import to runtime.
+
+    If the optional ``mcp`` dependency is not installed, exit non-zero with a
+    single-line install hint instead of dumping a ModuleNotFoundError traceback.
+    """
+    try:
+        from mcp_server.server import run
+    except ModuleNotFoundError as exc:
+        if _is_missing_mcp(exc):
+            print(MCP_MISSING_MESSAGE, file=sys.stderr)
+            raise SystemExit(1) from None
+        raise
 
     run()
+
+
+def _is_missing_mcp(exc: ModuleNotFoundError) -> bool:
+    """Return True if the import failure is the missing ``mcp`` package."""
+    name = exc.name or ""
+    return name == "mcp" or name.startswith("mcp.")

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,6 +1,6 @@
 """Allow running the MCP server via `python -m mcp_server`."""
 
-from mcp_server.server import main
+from mcp_server import main
 
 if __name__ == "__main__":
     main()

--- a/tests/test_extras_guards.py
+++ b/tests/test_extras_guards.py
@@ -1,0 +1,79 @@
+"""Tests for the optional-extras import guards.
+
+These exercise the missing-dependency paths without uninstalling anything: the
+real import is intercepted and made to raise ``ModuleNotFoundError``, then we
+assert the friendly install hint is surfaced instead of a bare traceback.
+"""
+
+import builtins
+import sys
+
+import pytest
+
+import duckdb_ext.extension as duckdb_ext
+import mcp_server
+
+
+def _import_blocker(blocked: str):
+    """Return an ``__import__`` replacement that fails for one top-level name."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == blocked or name.startswith(blocked + "."):
+            raise ModuleNotFoundError(f"No module named '{blocked}'", name=name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    return fake_import
+
+
+class TestMcpGuard:
+    def test_is_missing_mcp_matches_package(self):
+        assert mcp_server._is_missing_mcp(ModuleNotFoundError(name="mcp"))
+        assert mcp_server._is_missing_mcp(ModuleNotFoundError(name="mcp.server"))
+
+    def test_is_missing_mcp_ignores_other_modules(self):
+        assert not mcp_server._is_missing_mcp(ModuleNotFoundError(name="numpy"))
+        assert not mcp_server._is_missing_mcp(ModuleNotFoundError(name=None))
+
+    def test_main_exits_with_hint_when_mcp_missing(self, monkeypatch, capsys):
+        # Force a fresh import of mcp_server.server while mcp is unimportable.
+        for mod in list(sys.modules):
+            if (
+                mod == "mcp"
+                or mod.startswith("mcp.")
+                or mod.startswith("mcp_server.server")
+            ):
+                monkeypatch.delitem(sys.modules, mod, raising=False)
+        monkeypatch.setattr(builtins, "__import__", _import_blocker("mcp"))
+
+        with pytest.raises(SystemExit) as excinfo:
+            mcp_server.main()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.err.strip() == mcp_server.MCP_MISSING_MESSAGE
+        # Single line, no traceback dump.
+        assert captured.err.count("\n") == 1
+
+
+class TestDuckdbGuard:
+    def test_require_duckdb_returns_module_when_present(self):
+        assert duckdb_ext._require_duckdb() is sys.modules["duckdb"]
+
+    def test_require_duckdb_raises_hint_when_missing(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "duckdb", raising=False)
+        monkeypatch.setattr(builtins, "__import__", _import_blocker("duckdb"))
+
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            duckdb_ext._require_duckdb()
+
+        assert str(excinfo.value) == duckdb_ext.DUCKDB_MISSING_MESSAGE
+
+    def test_load_raises_hint_when_missing(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "duckdb", raising=False)
+        monkeypatch.setattr(builtins, "__import__", _import_blocker("duckdb"))
+
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            duckdb_ext.load()
+
+        assert str(excinfo.value) == duckdb_ext.DUCKDB_MISSING_MESSAGE

--- a/tests/test_extras_guards.py
+++ b/tests/test_extras_guards.py
@@ -6,9 +6,12 @@ assert the friendly install hint is surfaced instead of a bare traceback.
 """
 
 import builtins
+import importlib.util
 import sys
 
 import pytest
+
+_HAS_DUCKDB = importlib.util.find_spec("duckdb") is not None
 
 import duckdb_ext.extension as duckdb_ext
 import mcp_server
@@ -57,8 +60,11 @@ class TestMcpGuard:
 
 
 class TestDuckdbGuard:
+    @pytest.mark.skipif(not _HAS_DUCKDB, reason="duckdb extra not installed")
     def test_require_duckdb_returns_module_when_present(self):
-        assert duckdb_ext._require_duckdb() is sys.modules["duckdb"]
+        import duckdb
+
+        assert duckdb_ext._require_duckdb() is duckdb
 
     def test_require_duckdb_raises_hint_when_missing(self, monkeypatch):
         monkeypatch.delitem(sys.modules, "duckdb", raising=False)

--- a/tests/test_extras_guards.py
+++ b/tests/test_extras_guards.py
@@ -11,10 +11,10 @@ import sys
 
 import pytest
 
-_HAS_DUCKDB = importlib.util.find_spec("duckdb") is not None
-
 import duckdb_ext.extension as duckdb_ext
 import mcp_server
+
+_HAS_DUCKDB = importlib.util.find_spec("duckdb") is not None
 
 
 def _import_blocker(blocked: str):


### PR DESCRIPTION
## What this changes

Two small fixes from the review pass.

### Optional extras now fail with a useful message

Installing without the optional dependencies used to surface a raw `ModuleNotFoundError` when you tried to use the MCP server or DuckDB integration. Now both paths catch the missing import and tell you exactly what to install: "MCP support requires charted[mcp]. Install with..." and the equivalent for DuckDB. The guards only trigger on the genuinely missing optional package, so an unrelated import error still propagates normally.

### SECURITY.md rewritten

The old file was the stale template: it advertised a 0.1.x supported-version table and an `[INSERT SECURITY EMAIL]` placeholder. It now lists the real 1.1.x version and points reporters at GitHub private vulnerability reporting instead of a dead email placeholder.

## Not in this PR

A few review findings were deliberately left out:

1. Shrinking the 1988-line `chart.py` god class. Deferred to its own pass after PR #73 merges so the two efforts do not fight over the same file.
2. Adding Python 3.14 to the CI matrix and a mypy step to CI. These need a workflow-scope push, so they are handled separately.
3. The Development Status classifier (5 - Production/Stable) and the uv version pin mismatch. Left as maintainer judgment calls rather than changed automatically.
