### PR TITLE
ci: add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
charted declares `requires-python = ">=3.10, <3.15"` and the external review confirmed 3.14 passes locally, but CI only ran 3.10 to 3.13. This adds 3.14 to the matrix so the declared support is actually exercised.

If a dev dependency lacks a 3.14 wheel on the CI runner this may surface a packaging gap rather than a code problem; watching the run.