### PR TITLE
refactor: shrink chart.py further (render and scale clusters)

### DIFF
--- a/charted/charts/_chart_introspection.py
+++ b/charted/charts/_chart_introspection.py
@@ -1,0 +1,135 @@
+"""Introspection methods for charts.
+
+Extracted from the :class:`~charted.charts.chart.Chart` base class to reduce
+its size. The methods are unchanged; they are mixed back into ``Chart`` via
+the class bases, so they continue to operate on the same ``self``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from charted.utils.data_model import DataModel
+    from charted.utils.types import MeasuredText
+
+
+class ChartIntrospectionMixin:
+    """Read-only metadata behavior for :class:`Chart`.
+
+    Provides ``describe``, a structured-metadata accessor for agent workflows.
+    It relies on attributes supplied by the concrete chart class (``_width``,
+    ``_height``, ``_title``, ``data_model``, ``series_names`` and others); they
+    are declared here only for type checking. The ``_pie_data`` / ``_pie_labels``
+    attributes live on subclasses and are read under ``hasattr`` guards, so they
+    are not declared here.
+    """
+
+    if TYPE_CHECKING:
+        _width: float
+        _height: float
+        _title: MeasuredText | None
+        series_names: list[str] | None
+        data_model: DataModel
+
+        @property
+        def x_labels(self) -> list[MeasuredText] | None: ...
+
+        @property
+        def y_labels(self) -> list[MeasuredText] | None: ...
+
+        @property
+        def x_scale(self) -> str: ...
+
+        @property
+        def y_scale(self) -> str: ...
+
+    def describe(self) -> dict[str, object]:
+        """Return a structured dictionary of chart metadata.
+
+        Useful for AI agents that need to reason about a chart they just
+        created. Contains chart type, dimensions, series statistics,
+        labels, and layout flags.
+
+        Returns:
+            Dict with keys: chart_type, title, dimensions, series,
+            labels, label_count, series_count, theme, has_negative_values,
+            stacked.
+        """
+        # Determine the raw data series to compute stats over.
+        # PieChart stores its real data in _pie_data; base class gets synthetic data.
+        # BarChart stores values in x_data (horizontal bars); detect via x_stacked attr.
+        if hasattr(self, "_pie_data"):
+            raw_series = [self._pie_data]
+        elif getattr(self, "x_stacked", False) or (
+            self.data_model.x_data and self.__class__.__name__ == "BarChart"
+        ):
+            raw_series = self.data_model.x_data
+        else:
+            raw_series = self.data_model.y_data
+
+        # Build per-series stats
+        series_info = []
+        for i, series_data in enumerate(raw_series):
+            name = None
+            if self.series_names and i < len(self.series_names):
+                name = self.series_names[i]
+            count = len(series_data)
+            s_min = float(min(series_data))
+            s_max = float(max(series_data))
+            s_sum = float(sum(series_data))
+            s_mean = s_sum / count if count else 0.0
+            series_info.append(
+                {
+                    "name": name,
+                    "count": count,
+                    "min": s_min,
+                    "max": s_max,
+                    "mean": s_mean,
+                    "sum": s_sum,
+                }
+            )
+
+        # Determine labels list: check pie labels, then y_labels (BarChart),
+        # then x_labels (most chart types)
+        if hasattr(self, "_pie_labels") and self._pie_labels:
+            labels = [
+                lbl.text if hasattr(lbl, "text") else str(lbl)
+                for lbl in self._pie_labels
+            ]
+        elif self.y_labels:
+            labels = [
+                lbl.text if hasattr(lbl, "text") else str(lbl) for lbl in self.y_labels
+            ]
+        elif self.x_labels:
+            labels = [
+                lbl.text if hasattr(lbl, "text") else str(lbl) for lbl in self.x_labels
+            ]
+        else:
+            labels = None
+
+        label_count = (
+            len(labels) if labels else (len(raw_series[0]) if raw_series else 0)
+        )
+
+        # Detect negative values across all series
+        has_negative = any(val < 0 for series_data in raw_series for val in series_data)
+
+        # Stacked flag: either x_stacked (BarChart) or y_stacked (ColumnChart)
+        stacked = bool(
+            getattr(self, "x_stacked", False) or getattr(self, "y_stacked", False)
+        )
+
+        return {
+            "chart_type": self.__class__.__name__,
+            "title": self._title.text if self._title else None,
+            "dimensions": {"width": self._width, "height": self._height},
+            "series": series_info,
+            "labels": labels,
+            "label_count": label_count,
+            "series_count": len(raw_series),
+            "theme": "default",
+            "has_negative_values": has_negative,
+            "stacked": stacked,
+            "scales": {"x": self.x_scale, "y": self.y_scale},
+        }

--- a/charted/charts/_chart_references.py
+++ b/charted/charts/_chart_references.py
@@ -1,0 +1,236 @@
+"""Reference-line and axis-title rendering methods for charts.
+
+Extracted from the :class:`~charted.charts.chart.Chart` base class to reduce
+its size. The methods are unchanged; they are mixed back into ``Chart`` via
+the class bases, so they continue to operate on the same ``self``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from charted.html.element import G, Text
+
+if TYPE_CHECKING:
+    from charted.charts.chart import Chart, _Annotation
+    from charted.themes.core import Theme
+    from charted.utils.types import ReferenceLineDict
+
+
+class ChartReferenceLayerMixin:
+    """Reference-line and axis-title rendering for :class:`Chart`.
+
+    Builds the legacy ``h_lines`` / ``v_lines`` reference layer, the combined
+    annotation list, the rendered reference-line group (including label
+    callouts), and the x/y axis title labels. These rely on attributes and
+    layout properties supplied by the concrete chart class; they are declared
+    here only for type checking.
+    """
+
+    if TYPE_CHECKING:
+        _h_lines: list[float] | None
+        _v_lines: list[float] | None
+        _annotations: list[_Annotation]
+        _reference_line_labels: list[ReferenceLineDict]
+        _x_label: str | None
+        _y_label: str | None
+        _height: float
+        theme: Theme
+
+        @property
+        def left_padding(self) -> float: ...
+
+        @property
+        def top_padding(self) -> float: ...
+
+        @property
+        def plot_width(self) -> float: ...
+
+        @property
+        def plot_height(self) -> float: ...
+
+    def _collect_legacy_reference_lines(self) -> list[_Annotation]:
+        """Build the legacy ``h_lines`` / ``v_lines`` reference-line layer.
+
+        These are expressed as dashed full-span ``LineAnnotation`` objects so
+        there is a single rendering path. They are kept separate from
+        user-supplied annotations because reference lines span the full plot
+        and are intentionally not clipped, and their markup must stay
+        byte-for-byte identical to historical output.
+        """
+        from charted.charts.annotations import LineAnnotation
+
+        annotations: list[_Annotation] = []
+        if self._h_lines:
+            annotations.extend(LineAnnotation._h_line(v) for v in self._h_lines)
+        if self._v_lines:
+            annotations.extend(LineAnnotation._v_line(v) for v in self._v_lines)
+        return annotations
+
+    def _collect_annotations(self) -> list[_Annotation]:
+        """Build the full annotation list for this chart.
+
+        Legacy reference lines (``h_lines`` / ``v_lines``) come first, in their
+        historical order, followed by any user-supplied annotations.
+        """
+        return self._collect_legacy_reference_lines() + list(self._annotations)
+
+    def _render_reference_lines(self) -> G | None:
+        """Render the annotation layer (reference lines, boxes, labels).
+
+        Annotations are positioned in data coordinates and reprojected through
+        the axes, drawn inside the plot-area group. Legacy full-span reference
+        lines are drawn directly in the group; user annotations are drawn in a
+        nested group clipped to the plot area so out-of-domain boxes/labels
+        cannot bleed over the axes or off-canvas.
+        """
+        legacy = self._collect_legacy_reference_lines()
+        user_annotations = list(self._annotations)
+        if (
+            not legacy
+            and not user_annotations
+            and not getattr(self, "_reference_line_labels", [])
+        ):
+            return None
+
+        g = G(
+            transform=f"translate({self.left_padding}, {self.top_padding})",
+        )
+        # Full-span legacy h/v reference lines are drawn directly (unclipped),
+        # preserving byte-for-byte historical output.
+        chart = cast("Chart", self)
+        for annotation in legacy:
+            g.add_child(annotation.render(chart))
+
+        # User annotations (boxes, lines, labels) are clipped to the plot area
+        # using the same clip path as the scatter point group.
+        if user_annotations:
+            clipped = G(clip_path="url(#plot-clip)")
+            for annotation in user_annotations:
+                clipped.add_child(annotation.render(chart))
+            g.add_child(clipped)
+
+        # Render any reference-line labels supplied via the reference_lines API.
+        # The lines themselves are already drawn above (as LineAnnotations); this
+        # adds the text callouts next to them.
+        ref_labels = {}
+        for entry in getattr(self, "_reference_line_labels", []):
+            ref_labels[(entry["axis"], entry["value"])] = entry.get("label")
+
+        if ref_labels:
+            from charted.utils.helpers import calculate_text_dimensions
+
+            ref_color = self.theme.resolved_reference_line_color
+            label_font_size = max(8, self.theme.title_font_size - 4)
+            label_font_family = self.theme.title_font_family
+
+            for (axis, value), label in ref_labels.items():
+                if not label:
+                    continue
+                text_w = calculate_text_dimensions(
+                    str(label), font=label_font_family, font_size=label_font_size
+                ).width
+                if axis == "y":
+                    # The dashed line spans the full plot width. Anchor the label
+                    # to the line's right end, inside the plot, so it reads as a
+                    # callout on a continuous line rather than a floating tag next
+                    # to a clipped one. Sit it just below the line by default
+                    # (there is usually more clear space below a target line than
+                    # above it) and nudge it off any gridline it would touch.
+                    y = self.plot_height - chart.y_axis.reproject(value)
+                    label_x = self.plot_width - 4
+                    gap = label_font_size * 0.5
+                    # Candidate baseline below the line; flip above if that pushes
+                    # the text off the bottom of the plot.
+                    label_y = y + label_font_size + gap
+                    if label_y > self.plot_height - 2:
+                        label_y = y - gap
+                    # Keep the text band clear of horizontal gridlines.
+                    gridlines = [self.plot_height - c for c in chart.y_axis.coordinates]
+                    text_top = label_y - label_font_size
+                    for tick_y in gridlines:
+                        if text_top - 2 <= tick_y <= label_y + 2:
+                            # Gridline cuts through the text: shift the whole label
+                            # below that gridline (or above the line if no room).
+                            shifted = tick_y + label_font_size + gap
+                            label_y = (
+                                shifted if shifted < self.plot_height - 2 else y - gap
+                            )
+                            break
+                    g.add_child(
+                        Text(
+                            text=label,
+                            x=label_x,
+                            y=label_y,
+                            fill=ref_color,
+                            font_size=label_font_size,
+                            font_family=label_font_family,
+                            text_anchor="end",
+                        )
+                    )
+                else:
+                    x = chart.x_axis.reproject(value)
+                    # Keep the label fully on-canvas: anchor it to the left of the
+                    # line when it would otherwise overflow the right edge.
+                    if x + 4 + text_w > self.plot_width:
+                        label_x = x - 4
+                        anchor = "end"
+                    else:
+                        label_x = x + 4
+                        anchor = "start"
+                    g.add_child(
+                        Text(
+                            text=label,
+                            x=label_x,
+                            y=label_font_size,
+                            fill=ref_color,
+                            font_size=label_font_size,
+                            font_family=label_font_family,
+                            text_anchor=anchor,
+                        )
+                    )
+
+        return g
+
+    def _render_axis_labels(self) -> list[Text]:
+        """Render x-axis and y-axis title labels."""
+        elements: list[Text] = []
+        font_size = self.theme.title_font_size - 2
+        font_family = self.theme.title_font_family
+        font_color = self.theme.resolved_axis_title_color
+
+        if self._x_label:
+            # Centered below the x-axis, below the tick labels
+            x = self.left_padding + self.plot_width / 2
+            y = self._height - 2
+            elements.append(
+                Text(
+                    text=self._x_label,
+                    x=x,
+                    y=y,
+                    fill=font_color,
+                    font_size=font_size,
+                    font_family=font_family,
+                    text_anchor="middle",
+                )
+            )
+
+        if self._y_label:
+            # Centered along the y-axis, rotated -90 degrees
+            # Position outside (to the left of) the tick labels
+            x = font_size
+            y = self.top_padding + self.plot_height / 2
+            elements.append(
+                Text(
+                    text=self._y_label,
+                    x=x,
+                    y=y,
+                    fill=font_color,
+                    font_size=font_size,
+                    font_family=font_family,
+                    text_anchor="middle",
+                    transform=f"rotate(-90, {x}, {y})",
+                )
+            )
+
+        return elements

--- a/charted/charts/_chart_scales.py
+++ b/charted/charts/_chart_scales.py
@@ -1,0 +1,225 @@
+"""Scale and axis-data construction helpers for charts.
+
+Extracted from the :class:`~charted.charts.chart.Chart` base class to reduce
+its size. The methods are unchanged; they are mixed back into ``Chart`` via
+the class bases, so they continue to operate on the same ``self``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from charted.charts.scales import Scale
+    from charted.themes.core import Theme
+    from charted.utils.types import Vector, Vector2D
+
+
+class ChartScaleMixin:
+    """Scale/axis-data construction behavior for :class:`Chart`.
+
+    Provides the scale instantiation, time-data normalization, and axis-data
+    anchoring helpers used inside ``Chart.__init__``. These rely on attributes
+    supplied by the concrete chart class (``theme``, ``_domain_padding``); they
+    are declared here only for type checking.
+    """
+
+    if TYPE_CHECKING:
+        theme: Theme
+        _domain_padding: float | None
+
+    # Chart types whose value axis fills from a zero baseline (bars/columns).
+    # log/time scales are unsupported on that axis.
+    _BAR_VALUE_AXIS = {
+        "column": "y",
+        "area": "y",
+        "histogram": "y",
+        "bar": "x",
+    }
+
+    @classmethod
+    def _reject_unsupported_scales(
+        cls,
+        chart_type: str | None,
+        x_scale_inst: Scale | None,
+        y_scale_inst: Scale | None,
+    ) -> None:
+        """Raise ValueError for log/time scales on a bar/column value axis."""
+        value_axis = cls._BAR_VALUE_AXIS.get(cast("str", chart_type))
+        if value_axis is None:
+            return
+        scale = x_scale_inst if value_axis == "x" else y_scale_inst
+        if scale is None:
+            return
+        name = getattr(scale, "name", "linear")
+        if name in ("log", "time"):
+            raise ValueError(
+                f"{name!r} scale is not supported on the value axis "
+                f"({value_axis}) of a {chart_type} chart. Bar/column geometry "
+                f"fills from a zero baseline, which a log or time scale has no "
+                f"meaning for. Use a linear value axis, or switch to a line or "
+                f"scatter chart, which plot points instead of filled bars."
+            )
+
+    @staticmethod
+    def _is_time_scale(spec: object | None) -> bool:
+        from charted.charts.scales import TimeScale
+
+        return spec == "time" or isinstance(spec, TimeScale)
+
+    @staticmethod
+    def _normalize_time_data(x_data: Vector | Vector2D) -> Vector | Vector2D:
+        """Convert date/datetime/ISO-string x-data into epoch seconds."""
+        from charted.charts.scales import _to_epoch
+
+        def conv(seq: Vector) -> Vector:
+            return [_to_epoch(v) for v in seq]
+
+        if x_data and isinstance(x_data[0], list):
+            return [conv(row) for row in x_data]
+        return conv(cast("Vector", x_data))
+
+    def _anchor_axis_data(
+        self,
+        data: Vector2D,
+        fixed_range: tuple[float, float] | None,
+        zero_baseline: bool = False,
+        stacked: bool = False,
+    ) -> Vector2D:
+        """Return axis data anchored to a fixed range or padded domain.
+
+        The linear axes derive their domain (min/max) from the flattened data
+        they are given. To let callers control the visible span without adding
+        invisible data points, this appends synthetic anchor values so the
+        derived domain reaches the requested bounds:
+
+        - ``fixed_range`` (``x_range``/``y_range``): anchor to its exact
+          (min, max), replacing the data-derived domain.
+        - ``domain_padding``: a fractional pad applied to the data-derived
+          (min, max) on each side, e.g. ``0.1`` adds 10% of the data span as
+          headroom above and below.
+
+        ``zero_baseline`` marks a value axis whose geometry fills from zero
+        (bar/column/area/histogram). For these, padding the side that holds the
+        baseline would push the baseline off zero and distort every bar, so the
+        pad is only applied away from zero: above the tallest positive value,
+        below the lowest negative value, or both when the data straddles zero.
+        The zero baseline itself never moves.
+
+        When neither range nor padding is set the original data is returned
+        unchanged, so the historical auto-fit domain is byte-for-byte preserved.
+        """
+        if fixed_range is None and self._domain_padding is None:
+            return data
+        if not data or not any(row for row in data):
+            return data
+
+        # Determine the data-derived extent the axis will see. A stacked value
+        # axis aggregates per category (sum of positive series for the top, sum
+        # of negative series for the bottom), so the extent must be measured the
+        # same way or the headroom is computed against the wrong magnitude.
+        count = len(data[0])
+        if stacked:
+            tops = [0.0] * count
+            bottoms = [0.0] * count
+            for row in data:
+                for i in range(min(count, len(row))):
+                    v = row[i]
+                    if v < 0:
+                        bottoms[i] += v
+                    else:
+                        tops[i] += v
+            d_min, d_max = min(bottoms), max(tops)
+        else:
+            flat = [v for row in data for v in row]
+            d_min, d_max = min(flat), max(flat)
+
+        if fixed_range is not None:
+            lo, hi = min(fixed_range), max(fixed_range)
+        else:
+            span = d_max - d_min
+            # A zero span (single distinct value) has no fraction to pad; leave
+            # the data alone so the axis keeps its own degenerate-domain logic.
+            if span == 0:
+                return data
+            # When fixed_range is None the constructor guard guarantees
+            # _domain_padding is set; assert it for the type checker.
+            assert self._domain_padding is not None
+            pad = span * self._domain_padding
+            if zero_baseline:
+                # Keep the zero baseline pinned: only add headroom on the side
+                # away from zero. Positive-only data pads the top, negative-only
+                # pads the bottom, straddling data pads both.
+                lo = d_min - pad if d_min < 0 else d_min
+                hi = d_max + pad if d_max > 0 else d_max
+            else:
+                lo, hi = d_min - pad, d_max + pad
+
+        if stacked:
+            # The axis sums each category, so a short [lo, hi] anchor row would
+            # both crash the per-category loop and be summed into a column. Add
+            # full-width anchor rows whose top/bottom extremes already account
+            # for the existing stacked totals, so the aggregated max reaches hi
+            # and min reaches lo without inflating any real category.
+            top_row = [0.0] * count
+            bot_row = [0.0] * count
+            top_i = max(range(count), key=lambda i: tops[i])
+            bot_i = min(range(count), key=lambda i: bottoms[i])
+            if hi > tops[top_i]:
+                top_row[top_i] = hi - tops[top_i]
+            if lo < bottoms[bot_i]:
+                bot_row[bot_i] = lo - bottoms[bot_i]
+            return [*[list(row) for row in data], top_row, bot_row]
+
+        # Append the bounds as an extra series so min()/max() over the flattened
+        # data reach lo/hi without altering the plotted points themselves.
+        return [*[list(row) for row in data], [lo, hi]]
+
+    def _build_grid_config(self) -> str | dict[str, object]:
+        """Assemble the gridline config passed to each axis.
+
+        Returns the plain grid colour string when the theme requests no
+        gridline-hierarchy features, keeping existing renders unchanged. When a
+        dash pattern, an explicit major width, or minor subdivisions are set,
+        returns a dict carrying the major-line attributes plus the minor-grid
+        parameters (consumed by the axis grid_lines renderer).
+        """
+        theme = self.theme
+        color = theme.resolved_grid_color
+        width = theme.resolved_grid_width
+        dasharray = theme.grid_dasharray
+        divisions = theme.minor_grid_divisions
+
+        if width is None and dasharray is None and divisions <= 0:
+            return color
+
+        config: dict[str, object] = {
+            "stroke": color,
+            "stroke_dasharray": dasharray if dasharray is not None else "None",
+        }
+        if width is not None:
+            config["stroke_width"] = width
+        if divisions > 0:
+            config["minor_divisions"] = divisions
+            config["minor_stroke"] = theme.resolved_minor_grid_color
+            config["minor_stroke_width"] = theme.resolved_minor_grid_width
+        return config
+
+    def _build_scale(self, spec: object | None, data: Vector2D) -> Scale | None:
+        """Construct a Scale instance for an axis from its data domain.
+
+        Returns None for the default linear case so the axis keeps its
+        original tick math untouched.
+        """
+        from charted.charts.scales import Scale, make_scale
+
+        if spec is None or spec == "linear":
+            return None
+        flat = [v for row in data for v in row] if data else []
+        if not flat:
+            domain_min, domain_max = 0.0, 1.0
+        else:
+            domain_min, domain_max = min(flat), max(flat)
+        if isinstance(spec, Scale):
+            return spec
+        return make_scale(cast("str | Scale | None", spec), domain_min, domain_max)

--- a/charted/charts/_chart_value_labels.py
+++ b/charted/charts/_chart_value_labels.py
@@ -1,0 +1,260 @@
+"""Value-label methods for charts.
+
+Extracted from the :class:`~charted.charts.chart.Chart` base class to reduce
+its size. The methods are unchanged; they are mixed back into ``Chart`` via
+the class bases, so they continue to operate on the same ``self``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from charted.html.element import G, Text
+
+if TYPE_CHECKING:
+    from charted.charts.axes import YAxis
+    from charted.themes.core import Theme
+    from charted.utils.types import (
+        ValueLabelConfig,
+        ValueLabelOptions,
+        Vector2D,
+    )
+
+
+class ChartValueLabelMixin:
+    """Opt-in formatted value-label behavior for :class:`Chart`.
+
+    Normalizes the ``value_labels`` argument, synthesizes formatted label
+    strings from the raw data, and renders data labels onto data points. These
+    rely on attributes supplied by the concrete chart class; they are declared
+    here only for type checking.
+    """
+
+    if TYPE_CHECKING:
+        _value_label_config: ValueLabelConfig | None
+        _data_labels: list[str] | list[list[str]] | None
+        theme: Theme
+        y_axis: YAxis
+
+        @property
+        def x_offset(self) -> float: ...
+
+        @property
+        def plot_width(self) -> float: ...
+
+        @property
+        def plot_height(self) -> float: ...
+
+        @property
+        def y_data(self) -> Vector2D: ...
+
+        @property
+        def y_values(self) -> Vector2D: ...
+
+        @property
+        def y_offsets(self) -> Vector2D: ...
+
+        @property
+        def x_values(self) -> Vector2D: ...
+
+        @property
+        def colors(self) -> list[str]: ...
+
+        def _apply_stacking(self, y: float, y_offset: float) -> float: ...
+
+    @staticmethod
+    def _normalize_value_labels(
+        spec: bool | str | dict[str, object] | None,
+    ) -> ValueLabelConfig | None:
+        """Coerce the ``value_labels`` argument into a config dict or None.
+
+        Accepted forms:
+        - ``None`` / ``False``: feature off (returns None).
+        - ``True``: on with the default ``"number"`` format.
+        - a format string (``"number"`` / ``"percent"`` / ``"currency"``).
+        - a dict, e.g. ``{"format": "currency", "decimals": 2, "prefix": "US"}``.
+          A ``"format"`` key chooses the format; all other keys are passed
+          straight through to ``format_value`` as keyword options.
+
+        Foot-gun: the ``"percent"`` shorthand (and the dict form without an
+        explicit ``percent_scale``) defaults to ``percent_scale=True``, which
+        multiplies the raw value by 100 (``0.4`` -> ``"40%"``). That default
+        suits fractional data. If your data is *already* expressed in percent
+        units (``40`` meaning 40%), pass the dict form
+        ``{"format": "percent", "percent_scale": False}`` so the value renders
+        as ``"40%"`` rather than ``"4000%"``. The library cannot infer the
+        scale of arbitrary numbers, so the caller must say which one applies.
+        """
+        if spec is None or spec is False:
+            return None
+        if spec is True:
+            return {"format": "number"}
+        if isinstance(spec, str):
+            return {"format": spec}
+        if isinstance(spec, dict):
+            cfg: ValueLabelConfig = cast("ValueLabelConfig", dict(spec))
+            cfg.setdefault("format", "number")
+            return cfg
+        raise TypeError(
+            "value_labels must be None, a bool, a format string, or a dict; "
+            f"got {type(spec).__name__}"
+        )
+
+    def _value_label_data(self) -> Vector2D:
+        """Return the raw per-series values that value labels annotate.
+
+        Defaults to ``y_data``. Charts whose value axis is X (horizontal bars)
+        or whose data lives elsewhere (pie) override this.
+        """
+        return self.y_data
+
+    def _build_value_labels(self) -> list[list[str]] | None:
+        """Synthesize formatted label strings from the chart's raw values.
+
+        Returns a 2D list mirroring the value-data shape, or None when value
+        labels are disabled. Used by ``_render_data_labels`` as the label source
+        when no explicit ``data_labels`` were supplied.
+        """
+        cfg = self._value_label_config
+        if not cfg:
+            return None
+        from charted.utils.value_format import format_value
+
+        opts = cast(
+            "ValueLabelOptions",
+            {k: v for k, v in cfg.items() if k != "format"},
+        )
+        fmt = cfg["format"]
+        data = self._value_label_data()
+        return [[format_value(v, fmt, **opts) for v in row] for row in data]
+
+    @property
+    def _data_label_x_offset(self) -> float:
+        return 0
+
+    @property
+    def _data_labels_use_contrast(self) -> bool:
+        return False
+
+    def _render_data_labels(self) -> G | None:
+        """Render data labels on data points.
+
+        Returns a G element with text labels positioned at each data point.
+        Subclasses call this from their representation property.
+
+        When no explicit ``data_labels`` are supplied but ``value_labels`` is
+        enabled, the labels are synthesized from the raw data with the requested
+        number/percent/currency formatting, and any label whose box would
+        collide with an already-placed one is hidden.
+        """
+        from charted.utils.colors import get_contrast_color
+
+        labels = self._data_labels
+        auto_hide = False
+        if not labels:
+            labels = self._build_value_labels()
+            auto_hide = labels is not None
+        if not labels:
+            return None
+
+        # Normalize to 2D list
+        if labels and not isinstance(labels[0], list):
+            labels = [labels]
+
+        g = G()
+        font_size = max(8, self.theme.title_font_size - 4)
+        font_family = self.theme.title_font_family
+        font_color = self.theme.resolved_data_label_color
+
+        # Track placed label boxes (in plot coordinates) so value labels can be
+        # auto-hidden when they would collide with an already-placed label.
+        placed_boxes: list[tuple[float, float, float, float]] = []
+
+        from charted.utils.helpers import calculate_text_dimensions
+
+        for series_idx, label_row in enumerate(labels):
+            if series_idx >= len(self.y_values):
+                break
+            y_vals = self.y_values[series_idx]
+            y_offs = self.y_offsets[series_idx]
+            x_vals = self.x_values[series_idx]
+            series_color = (
+                self.colors[series_idx] if series_idx < len(self.colors) else None
+            )
+
+            for i, label_text in enumerate(label_row):
+                if i >= len(x_vals) or not label_text:
+                    continue
+                x = x_vals[i] + self.x_offset + self._data_label_x_offset
+                y = self._apply_stacking(y_vals[i], y_offs[i])
+                label_offset = font_size + 4
+                if y_vals[i] < 0:
+                    ty = y + label_offset + font_size
+                else:
+                    ty = y - label_offset
+                anchor = "middle"
+                # Clamp labels that would go off-chart vertically
+                if ty < font_size:
+                    ty = y + label_offset + font_size
+                if ty > self.plot_height - font_size:
+                    ty = y - label_offset
+                # Detect if label is inside the bar/column area
+                inside = self._data_labels_use_contrast and (
+                    (y_vals[i] >= 0 and 0 < ty < y) or (y_vals[i] < 0 and y < ty < 0)
+                )
+                # Nudge label away from grid lines for breathing room
+                grid_margin = font_size * 0.6
+                if hasattr(self, "y_axis"):
+                    for tick_y in self.y_axis.coordinates:
+                        if abs(ty - tick_y) < grid_margin:
+                            ty = (
+                                tick_y - grid_margin
+                                if ty > tick_y
+                                else tick_y + grid_margin
+                            )
+                            break
+                # Use contrast-aware color when label is inside a colored area
+                fill = font_color
+                if inside and series_color:
+                    fill = get_contrast_color(series_color)
+                # Clamp labels at horizontal edges
+                if x > self.plot_width * 0.85:
+                    anchor = "end"
+                elif x < self.plot_width * 0.15:
+                    anchor = "start"
+                # Auto-hide synthesized value labels that would overlap an
+                # already-placed one. Explicit data_labels are left untouched so
+                # historical renders stay byte-for-byte identical.
+                if auto_hide:
+                    tw = calculate_text_dimensions(
+                        str(label_text), font=font_family, font_size=font_size
+                    ).width
+                    box = (
+                        x - tw / 2,
+                        ty - font_size / 2,
+                        x + tw / 2,
+                        ty + font_size / 2,
+                    )
+                    if any(
+                        box[0] < pb[2]
+                        and box[2] > pb[0]
+                        and box[1] < pb[3]
+                        and box[3] > pb[1]
+                        for pb in placed_boxes
+                    ):
+                        continue
+                    placed_boxes.append(box)
+                g.add_child(
+                    Text(
+                        text=str(label_text),
+                        x=x,
+                        y=ty,
+                        fill=fill,
+                        font_size=font_size,
+                        font_family=font_family,
+                        text_anchor=anchor,
+                        transform=f"translate({x},{ty}) scale(1,-1) translate({-x},{-ty})",
+                    )
+                )
+
+        return g

--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, cast
 
 from charted.charts._chart_config import ChartConfigMixin
+from charted.charts._chart_introspection import ChartIntrospectionMixin
 from charted.charts._chart_output import ChartOutputMixin
 from charted.charts._chart_patterns import ChartPatternMixin
 from charted.charts._chart_tooltips import ChartTooltipMixin
@@ -56,6 +57,7 @@ class _Annotation(Protocol):
 
 
 class Chart(
+    ChartIntrospectionMixin,
     ChartPatternMixin,
     ChartConfigMixin,
     ChartTooltipMixin,
@@ -1141,100 +1143,6 @@ class Chart(
             top_padding=self.top_padding,
             plot_height=self.plot_height,
         )
-
-    # =========================================================================
-    # Introspection
-    # =========================================================================
-
-    def describe(self) -> dict[str, object]:
-        """Return a structured dictionary of chart metadata.
-
-        Useful for AI agents that need to reason about a chart they just
-        created. Contains chart type, dimensions, series statistics,
-        labels, and layout flags.
-
-        Returns:
-            Dict with keys: chart_type, title, dimensions, series,
-            labels, label_count, series_count, theme, has_negative_values,
-            stacked.
-        """
-        # Determine the raw data series to compute stats over.
-        # PieChart stores its real data in _pie_data; base class gets synthetic data.
-        # BarChart stores values in x_data (horizontal bars); detect via x_stacked attr.
-        if hasattr(self, "_pie_data"):
-            raw_series = [self._pie_data]
-        elif getattr(self, "x_stacked", False) or (
-            self.data_model.x_data and self.__class__.__name__ == "BarChart"
-        ):
-            raw_series = self.data_model.x_data
-        else:
-            raw_series = self.data_model.y_data
-
-        # Build per-series stats
-        series_info = []
-        for i, series_data in enumerate(raw_series):
-            name = None
-            if self.series_names and i < len(self.series_names):
-                name = self.series_names[i]
-            count = len(series_data)
-            s_min = float(min(series_data))
-            s_max = float(max(series_data))
-            s_sum = float(sum(series_data))
-            s_mean = s_sum / count if count else 0.0
-            series_info.append(
-                {
-                    "name": name,
-                    "count": count,
-                    "min": s_min,
-                    "max": s_max,
-                    "mean": s_mean,
-                    "sum": s_sum,
-                }
-            )
-
-        # Determine labels list: check pie labels, then y_labels (BarChart),
-        # then x_labels (most chart types)
-        if hasattr(self, "_pie_labels") and self._pie_labels:
-            labels = [
-                lbl.text if hasattr(lbl, "text") else str(lbl)
-                for lbl in self._pie_labels
-            ]
-        elif self.y_labels:
-            labels = [
-                lbl.text if hasattr(lbl, "text") else str(lbl) for lbl in self.y_labels
-            ]
-        elif self.x_labels:
-            labels = [
-                lbl.text if hasattr(lbl, "text") else str(lbl) for lbl in self.x_labels
-            ]
-        else:
-            labels = None
-
-        label_count = (
-            len(labels) if labels else (len(raw_series[0]) if raw_series else 0)
-        )
-
-        # Detect negative values across all series
-        has_negative = any(val < 0 for series_data in raw_series for val in series_data)
-
-        # Stacked flag: either x_stacked (BarChart) or y_stacked (ColumnChart)
-        stacked = bool(
-            getattr(self, "x_stacked", False) or getattr(self, "y_stacked", False)
-        )
-
-        return {
-            "chart_type": self.__class__.__name__,
-            "title": self._title.text if self._title else None,
-            "dimensions": {"width": self._width, "height": self._height},
-            "series": series_info,
-            "labels": labels,
-            "label_count": label_count,
-            "series_count": len(raw_series),
-            "theme": "default",
-            "has_negative_values": has_negative,
-            "stacked": stacked,
-            "scales": {"x": self.x_scale, "y": self.y_scale},
-        }
 
     # =========================================================================
     # Reference Lines & Axis Labels

--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -13,6 +13,7 @@ from charted.charts._chart_introspection import ChartIntrospectionMixin
 from charted.charts._chart_output import ChartOutputMixin
 from charted.charts._chart_patterns import ChartPatternMixin
 from charted.charts._chart_references import ChartReferenceLayerMixin
+from charted.charts._chart_scales import ChartScaleMixin
 from charted.charts._chart_tooltips import ChartTooltipMixin
 from charted.charts._chart_value_labels import ChartValueLabelMixin
 from charted.charts.axes import XAxis, YAxis
@@ -41,7 +42,6 @@ from charted.utils.types import (
 
 if TYPE_CHECKING:
     from charted.charts.axes import _AxisParent
-    from charted.charts.scales import Scale
     from charted.html.element import Element
 
 
@@ -57,6 +57,7 @@ class _Annotation(Protocol):
 
 
 class Chart(
+    ChartScaleMixin,
     ChartValueLabelMixin,
     ChartReferenceLayerMixin,
     ChartIntrospectionMixin,
@@ -610,202 +611,6 @@ class Chart(
     # =========================================================================
     # Scale Helpers
     # =========================================================================
-
-    # Chart types whose value axis fills from a zero baseline (bars/columns).
-    # log/time scales are unsupported on that axis.
-    _BAR_VALUE_AXIS = {
-        "column": "y",
-        "area": "y",
-        "histogram": "y",
-        "bar": "x",
-    }
-
-    @classmethod
-    def _reject_unsupported_scales(
-        cls,
-        chart_type: str | None,
-        x_scale_inst: Scale | None,
-        y_scale_inst: Scale | None,
-    ) -> None:
-        """Raise ValueError for log/time scales on a bar/column value axis."""
-        value_axis = cls._BAR_VALUE_AXIS.get(cast("str", chart_type))
-        if value_axis is None:
-            return
-        scale = x_scale_inst if value_axis == "x" else y_scale_inst
-        if scale is None:
-            return
-        name = getattr(scale, "name", "linear")
-        if name in ("log", "time"):
-            raise ValueError(
-                f"{name!r} scale is not supported on the value axis "
-                f"({value_axis}) of a {chart_type} chart. Bar/column geometry "
-                f"fills from a zero baseline, which a log or time scale has no "
-                f"meaning for. Use a linear value axis, or switch to a line or "
-                f"scatter chart, which plot points instead of filled bars."
-            )
-
-    @staticmethod
-    def _is_time_scale(spec: object | None) -> bool:
-        from charted.charts.scales import TimeScale
-
-        return spec == "time" or isinstance(spec, TimeScale)
-
-    @staticmethod
-    def _normalize_time_data(x_data: Vector | Vector2D) -> Vector | Vector2D:
-        """Convert date/datetime/ISO-string x-data into epoch seconds."""
-        from charted.charts.scales import _to_epoch
-
-        def conv(seq: Vector) -> Vector:
-            return [_to_epoch(v) for v in seq]
-
-        if x_data and isinstance(x_data[0], list):
-            return [conv(row) for row in x_data]
-        return conv(cast("Vector", x_data))
-
-    def _anchor_axis_data(
-        self,
-        data: Vector2D,
-        fixed_range: tuple[float, float] | None,
-        zero_baseline: bool = False,
-        stacked: bool = False,
-    ) -> Vector2D:
-        """Return axis data anchored to a fixed range or padded domain.
-
-        The linear axes derive their domain (min/max) from the flattened data
-        they are given. To let callers control the visible span without adding
-        invisible data points, this appends synthetic anchor values so the
-        derived domain reaches the requested bounds:
-
-        - ``fixed_range`` (``x_range``/``y_range``): anchor to its exact
-          (min, max), replacing the data-derived domain.
-        - ``domain_padding``: a fractional pad applied to the data-derived
-          (min, max) on each side, e.g. ``0.1`` adds 10% of the data span as
-          headroom above and below.
-
-        ``zero_baseline`` marks a value axis whose geometry fills from zero
-        (bar/column/area/histogram). For these, padding the side that holds the
-        baseline would push the baseline off zero and distort every bar, so the
-        pad is only applied away from zero: above the tallest positive value,
-        below the lowest negative value, or both when the data straddles zero.
-        The zero baseline itself never moves.
-
-        When neither range nor padding is set the original data is returned
-        unchanged, so the historical auto-fit domain is byte-for-byte preserved.
-        """
-        if fixed_range is None and self._domain_padding is None:
-            return data
-        if not data or not any(row for row in data):
-            return data
-
-        # Determine the data-derived extent the axis will see. A stacked value
-        # axis aggregates per category (sum of positive series for the top, sum
-        # of negative series for the bottom), so the extent must be measured the
-        # same way or the headroom is computed against the wrong magnitude.
-        count = len(data[0])
-        if stacked:
-            tops = [0.0] * count
-            bottoms = [0.0] * count
-            for row in data:
-                for i in range(min(count, len(row))):
-                    v = row[i]
-                    if v < 0:
-                        bottoms[i] += v
-                    else:
-                        tops[i] += v
-            d_min, d_max = min(bottoms), max(tops)
-        else:
-            flat = [v for row in data for v in row]
-            d_min, d_max = min(flat), max(flat)
-
-        if fixed_range is not None:
-            lo, hi = min(fixed_range), max(fixed_range)
-        else:
-            span = d_max - d_min
-            # A zero span (single distinct value) has no fraction to pad; leave
-            # the data alone so the axis keeps its own degenerate-domain logic.
-            if span == 0:
-                return data
-            # When fixed_range is None the constructor guard guarantees
-            # _domain_padding is set; assert it for the type checker.
-            assert self._domain_padding is not None
-            pad = span * self._domain_padding
-            if zero_baseline:
-                # Keep the zero baseline pinned: only add headroom on the side
-                # away from zero. Positive-only data pads the top, negative-only
-                # pads the bottom, straddling data pads both.
-                lo = d_min - pad if d_min < 0 else d_min
-                hi = d_max + pad if d_max > 0 else d_max
-            else:
-                lo, hi = d_min - pad, d_max + pad
-
-        if stacked:
-            # The axis sums each category, so a short [lo, hi] anchor row would
-            # both crash the per-category loop and be summed into a column. Add
-            # full-width anchor rows whose top/bottom extremes already account
-            # for the existing stacked totals, so the aggregated max reaches hi
-            # and min reaches lo without inflating any real category.
-            top_row = [0.0] * count
-            bot_row = [0.0] * count
-            top_i = max(range(count), key=lambda i: tops[i])
-            bot_i = min(range(count), key=lambda i: bottoms[i])
-            if hi > tops[top_i]:
-                top_row[top_i] = hi - tops[top_i]
-            if lo < bottoms[bot_i]:
-                bot_row[bot_i] = lo - bottoms[bot_i]
-            return [*[list(row) for row in data], top_row, bot_row]
-
-        # Append the bounds as an extra series so min()/max() over the flattened
-        # data reach lo/hi without altering the plotted points themselves.
-        return [*[list(row) for row in data], [lo, hi]]
-
-    def _build_grid_config(self) -> str | dict[str, object]:
-        """Assemble the gridline config passed to each axis.
-
-        Returns the plain grid colour string when the theme requests no
-        gridline-hierarchy features, keeping existing renders unchanged. When a
-        dash pattern, an explicit major width, or minor subdivisions are set,
-        returns a dict carrying the major-line attributes plus the minor-grid
-        parameters (consumed by the axis grid_lines renderer).
-        """
-        theme = self.theme
-        color = theme.resolved_grid_color
-        width = theme.resolved_grid_width
-        dasharray = theme.grid_dasharray
-        divisions = theme.minor_grid_divisions
-
-        if width is None and dasharray is None and divisions <= 0:
-            return color
-
-        config: dict[str, object] = {
-            "stroke": color,
-            "stroke_dasharray": dasharray if dasharray is not None else "None",
-        }
-        if width is not None:
-            config["stroke_width"] = width
-        if divisions > 0:
-            config["minor_divisions"] = divisions
-            config["minor_stroke"] = theme.resolved_minor_grid_color
-            config["minor_stroke_width"] = theme.resolved_minor_grid_width
-        return config
-
-    def _build_scale(self, spec: object | None, data: Vector2D) -> Scale | None:
-        """Construct a Scale instance for an axis from its data domain.
-
-        Returns None for the default linear case so the axis keeps its
-        original tick math untouched.
-        """
-        from charted.charts.scales import Scale, make_scale
-
-        if spec is None or spec == "linear":
-            return None
-        flat = [v for row in data for v in row] if data else []
-        if not flat:
-            domain_min, domain_max = 0.0, 1.0
-        else:
-            domain_min, domain_max = min(flat), max(flat)
-        if isinstance(spec, Scale):
-            return spec
-        return make_scale(cast("str | Scale | None", spec), domain_min, domain_max)
 
     @property
     def x_scale(self) -> str:

--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -12,6 +12,7 @@ from charted.charts._chart_config import ChartConfigMixin
 from charted.charts._chart_introspection import ChartIntrospectionMixin
 from charted.charts._chart_output import ChartOutputMixin
 from charted.charts._chart_patterns import ChartPatternMixin
+from charted.charts._chart_references import ChartReferenceLayerMixin
 from charted.charts._chart_tooltips import ChartTooltipMixin
 from charted.charts.axes import XAxis, YAxis
 from charted.constants import (
@@ -57,6 +58,7 @@ class _Annotation(Protocol):
 
 
 class Chart(
+    ChartReferenceLayerMixin,
     ChartIntrospectionMixin,
     ChartPatternMixin,
     ChartConfigMixin,
@@ -1143,195 +1145,6 @@ class Chart(
             top_padding=self.top_padding,
             plot_height=self.plot_height,
         )
-
-    # =========================================================================
-    # Reference Lines & Axis Labels
-    # =========================================================================
-
-    def _collect_legacy_reference_lines(self) -> list[_Annotation]:
-        """Build the legacy ``h_lines`` / ``v_lines`` reference-line layer.
-
-        These are expressed as dashed full-span ``LineAnnotation`` objects so
-        there is a single rendering path. They are kept separate from
-        user-supplied annotations because reference lines span the full plot
-        and are intentionally not clipped, and their markup must stay
-        byte-for-byte identical to historical output.
-        """
-        from charted.charts.annotations import LineAnnotation
-
-        annotations: list[_Annotation] = []
-        if self._h_lines:
-            annotations.extend(LineAnnotation._h_line(v) for v in self._h_lines)
-        if self._v_lines:
-            annotations.extend(LineAnnotation._v_line(v) for v in self._v_lines)
-        return annotations
-
-    def _collect_annotations(self) -> list[_Annotation]:
-        """Build the full annotation list for this chart.
-
-        Legacy reference lines (``h_lines`` / ``v_lines``) come first, in their
-        historical order, followed by any user-supplied annotations.
-        """
-        return self._collect_legacy_reference_lines() + list(self._annotations)
-
-    def _render_reference_lines(self) -> G | None:
-        """Render the annotation layer (reference lines, boxes, labels).
-
-        Annotations are positioned in data coordinates and reprojected through
-        the axes, drawn inside the plot-area group. Legacy full-span reference
-        lines are drawn directly in the group; user annotations are drawn in a
-        nested group clipped to the plot area so out-of-domain boxes/labels
-        cannot bleed over the axes or off-canvas.
-        """
-        legacy = self._collect_legacy_reference_lines()
-        user_annotations = list(self._annotations)
-        if (
-            not legacy
-            and not user_annotations
-            and not getattr(self, "_reference_line_labels", [])
-        ):
-            return None
-
-        g = G(
-            transform=f"translate({self.left_padding}, {self.top_padding})",
-        )
-        # Full-span legacy h/v reference lines are drawn directly (unclipped),
-        # preserving byte-for-byte historical output.
-        for annotation in legacy:
-            g.add_child(annotation.render(self))
-
-        # User annotations (boxes, lines, labels) are clipped to the plot area
-        # using the same clip path as the scatter point group.
-        if user_annotations:
-            clipped = G(clip_path="url(#plot-clip)")
-            for annotation in user_annotations:
-                clipped.add_child(annotation.render(self))
-            g.add_child(clipped)
-
-        # Render any reference-line labels supplied via the reference_lines API.
-        # The lines themselves are already drawn above (as LineAnnotations); this
-        # adds the text callouts next to them.
-        ref_labels = {}
-        for entry in getattr(self, "_reference_line_labels", []):
-            ref_labels[(entry["axis"], entry["value"])] = entry.get("label")
-
-        if ref_labels:
-            from charted.utils.helpers import calculate_text_dimensions
-
-            ref_color = self.theme.resolved_reference_line_color
-            label_font_size = max(8, self.theme.title_font_size - 4)
-            label_font_family = self.theme.title_font_family
-
-            for (axis, value), label in ref_labels.items():
-                if not label:
-                    continue
-                text_w = calculate_text_dimensions(
-                    str(label), font=label_font_family, font_size=label_font_size
-                ).width
-                if axis == "y":
-                    # The dashed line spans the full plot width. Anchor the label
-                    # to the line's right end, inside the plot, so it reads as a
-                    # callout on a continuous line rather than a floating tag next
-                    # to a clipped one. Sit it just below the line by default
-                    # (there is usually more clear space below a target line than
-                    # above it) and nudge it off any gridline it would touch.
-                    y = self.plot_height - self.y_axis.reproject(value)
-                    label_x = self.plot_width - 4
-                    gap = label_font_size * 0.5
-                    # Candidate baseline below the line; flip above if that pushes
-                    # the text off the bottom of the plot.
-                    label_y = y + label_font_size + gap
-                    if label_y > self.plot_height - 2:
-                        label_y = y - gap
-                    # Keep the text band clear of horizontal gridlines.
-                    gridlines = [self.plot_height - c for c in self.y_axis.coordinates]
-                    text_top = label_y - label_font_size
-                    for tick_y in gridlines:
-                        if text_top - 2 <= tick_y <= label_y + 2:
-                            # Gridline cuts through the text: shift the whole label
-                            # below that gridline (or above the line if no room).
-                            shifted = tick_y + label_font_size + gap
-                            label_y = (
-                                shifted if shifted < self.plot_height - 2 else y - gap
-                            )
-                            break
-                    g.add_child(
-                        Text(
-                            text=label,
-                            x=label_x,
-                            y=label_y,
-                            fill=ref_color,
-                            font_size=label_font_size,
-                            font_family=label_font_family,
-                            text_anchor="end",
-                        )
-                    )
-                else:
-                    x = self.x_axis.reproject(value)
-                    # Keep the label fully on-canvas: anchor it to the left of the
-                    # line when it would otherwise overflow the right edge.
-                    if x + 4 + text_w > self.plot_width:
-                        label_x = x - 4
-                        anchor = "end"
-                    else:
-                        label_x = x + 4
-                        anchor = "start"
-                    g.add_child(
-                        Text(
-                            text=label,
-                            x=label_x,
-                            y=label_font_size,
-                            fill=ref_color,
-                            font_size=label_font_size,
-                            font_family=label_font_family,
-                            text_anchor=anchor,
-                        )
-                    )
-
-        return g
-
-    def _render_axis_labels(self) -> list[Text]:
-        """Render x-axis and y-axis title labels."""
-        elements: list[Text] = []
-        font_size = self.theme.title_font_size - 2
-        font_family = self.theme.title_font_family
-        font_color = self.theme.resolved_axis_title_color
-
-        if self._x_label:
-            # Centered below the x-axis, below the tick labels
-            x = self.left_padding + self.plot_width / 2
-            y = self._height - 2
-            elements.append(
-                Text(
-                    text=self._x_label,
-                    x=x,
-                    y=y,
-                    fill=font_color,
-                    font_size=font_size,
-                    font_family=font_family,
-                    text_anchor="middle",
-                )
-            )
-
-        if self._y_label:
-            # Centered along the y-axis, rotated -90 degrees
-            # Position outside (to the left of) the tick labels
-            x = font_size
-            y = self.top_padding + self.plot_height / 2
-            elements.append(
-                Text(
-                    text=self._y_label,
-                    x=x,
-                    y=y,
-                    fill=font_color,
-                    font_size=font_size,
-                    font_family=font_family,
-                    text_anchor="middle",
-                    transform=f"rotate(-90, {x}, {y})",
-                )
-            )
-
-        return elements
 
     # =========================================================================
     # Value labels (opt-in, formatted on-element data annotations)

--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -14,6 +14,7 @@ from charted.charts._chart_output import ChartOutputMixin
 from charted.charts._chart_patterns import ChartPatternMixin
 from charted.charts._chart_references import ChartReferenceLayerMixin
 from charted.charts._chart_tooltips import ChartTooltipMixin
+from charted.charts._chart_value_labels import ChartValueLabelMixin
 from charted.charts.axes import XAxis, YAxis
 from charted.constants import (
     AXIS_BORDER_COLOR,
@@ -34,8 +35,6 @@ from charted.utils.types import (
     MeasuredText,
     ReferenceLineDict,
     SeriesStyleConfig,
-    ValueLabelConfig,
-    ValueLabelOptions,
     Vector,
     Vector2D,
 )
@@ -58,6 +57,7 @@ class _Annotation(Protocol):
 
 
 class Chart(
+    ChartValueLabelMixin,
     ChartReferenceLayerMixin,
     ChartIntrospectionMixin,
     ChartPatternMixin,
@@ -1145,207 +1145,6 @@ class Chart(
             top_padding=self.top_padding,
             plot_height=self.plot_height,
         )
-
-    # =========================================================================
-    # Value labels (opt-in, formatted on-element data annotations)
-    # =========================================================================
-
-    @staticmethod
-    def _normalize_value_labels(
-        spec: bool | str | dict[str, object] | None,
-    ) -> ValueLabelConfig | None:
-        """Coerce the ``value_labels`` argument into a config dict or None.
-
-        Accepted forms:
-        - ``None`` / ``False``: feature off (returns None).
-        - ``True``: on with the default ``"number"`` format.
-        - a format string (``"number"`` / ``"percent"`` / ``"currency"``).
-        - a dict, e.g. ``{"format": "currency", "decimals": 2, "prefix": "US"}``.
-          A ``"format"`` key chooses the format; all other keys are passed
-          straight through to ``format_value`` as keyword options.
-
-        Foot-gun: the ``"percent"`` shorthand (and the dict form without an
-        explicit ``percent_scale``) defaults to ``percent_scale=True``, which
-        multiplies the raw value by 100 (``0.4`` -> ``"40%"``). That default
-        suits fractional data. If your data is *already* expressed in percent
-        units (``40`` meaning 40%), pass the dict form
-        ``{"format": "percent", "percent_scale": False}`` so the value renders
-        as ``"40%"`` rather than ``"4000%"``. The library cannot infer the
-        scale of arbitrary numbers, so the caller must say which one applies.
-        """
-        if spec is None or spec is False:
-            return None
-        if spec is True:
-            return {"format": "number"}
-        if isinstance(spec, str):
-            return {"format": spec}
-        if isinstance(spec, dict):
-            cfg: ValueLabelConfig = cast("ValueLabelConfig", dict(spec))
-            cfg.setdefault("format", "number")
-            return cfg
-        raise TypeError(
-            "value_labels must be None, a bool, a format string, or a dict; "
-            f"got {type(spec).__name__}"
-        )
-
-    def _value_label_data(self) -> Vector2D:
-        """Return the raw per-series values that value labels annotate.
-
-        Defaults to ``y_data``. Charts whose value axis is X (horizontal bars)
-        or whose data lives elsewhere (pie) override this.
-        """
-        return self.y_data
-
-    def _build_value_labels(self) -> list[list[str]] | None:
-        """Synthesize formatted label strings from the chart's raw values.
-
-        Returns a 2D list mirroring the value-data shape, or None when value
-        labels are disabled. Used by ``_render_data_labels`` as the label source
-        when no explicit ``data_labels`` were supplied.
-        """
-        cfg = self._value_label_config
-        if not cfg:
-            return None
-        from charted.utils.value_format import format_value
-
-        opts = cast(
-            "ValueLabelOptions",
-            {k: v for k, v in cfg.items() if k != "format"},
-        )
-        fmt = cfg["format"]
-        data = self._value_label_data()
-        return [[format_value(v, fmt, **opts) for v in row] for row in data]
-
-    @property
-    def _data_label_x_offset(self) -> float:
-        return 0
-
-    @property
-    def _data_labels_use_contrast(self) -> bool:
-        return False
-
-    def _render_data_labels(self) -> G | None:
-        """Render data labels on data points.
-
-        Returns a G element with text labels positioned at each data point.
-        Subclasses call this from their representation property.
-
-        When no explicit ``data_labels`` are supplied but ``value_labels`` is
-        enabled, the labels are synthesized from the raw data with the requested
-        number/percent/currency formatting, and any label whose box would
-        collide with an already-placed one is hidden.
-        """
-        from charted.utils.colors import get_contrast_color
-
-        labels = self._data_labels
-        auto_hide = False
-        if not labels:
-            labels = self._build_value_labels()
-            auto_hide = labels is not None
-        if not labels:
-            return None
-
-        # Normalize to 2D list
-        if labels and not isinstance(labels[0], list):
-            labels = [labels]
-
-        g = G()
-        font_size = max(8, self.theme.title_font_size - 4)
-        font_family = self.theme.title_font_family
-        font_color = self.theme.resolved_data_label_color
-
-        # Track placed label boxes (in plot coordinates) so value labels can be
-        # auto-hidden when they would collide with an already-placed label.
-        placed_boxes: list[tuple[float, float, float, float]] = []
-
-        from charted.utils.helpers import calculate_text_dimensions
-
-        for series_idx, label_row in enumerate(labels):
-            if series_idx >= len(self.y_values):
-                break
-            y_vals = self.y_values[series_idx]
-            y_offs = self.y_offsets[series_idx]
-            x_vals = self.x_values[series_idx]
-            series_color = (
-                self.colors[series_idx] if series_idx < len(self.colors) else None
-            )
-
-            for i, label_text in enumerate(label_row):
-                if i >= len(x_vals) or not label_text:
-                    continue
-                x = x_vals[i] + self.x_offset + self._data_label_x_offset
-                y = self._apply_stacking(y_vals[i], y_offs[i])
-                label_offset = font_size + 4
-                if y_vals[i] < 0:
-                    ty = y + label_offset + font_size
-                else:
-                    ty = y - label_offset
-                anchor = "middle"
-                # Clamp labels that would go off-chart vertically
-                if ty < font_size:
-                    ty = y + label_offset + font_size
-                if ty > self.plot_height - font_size:
-                    ty = y - label_offset
-                # Detect if label is inside the bar/column area
-                inside = self._data_labels_use_contrast and (
-                    (y_vals[i] >= 0 and 0 < ty < y) or (y_vals[i] < 0 and y < ty < 0)
-                )
-                # Nudge label away from grid lines for breathing room
-                grid_margin = font_size * 0.6
-                if hasattr(self, "y_axis"):
-                    for tick_y in self.y_axis.coordinates:
-                        if abs(ty - tick_y) < grid_margin:
-                            ty = (
-                                tick_y - grid_margin
-                                if ty > tick_y
-                                else tick_y + grid_margin
-                            )
-                            break
-                # Use contrast-aware color when label is inside a colored area
-                fill = font_color
-                if inside and series_color:
-                    fill = get_contrast_color(series_color)
-                # Clamp labels at horizontal edges
-                if x > self.plot_width * 0.85:
-                    anchor = "end"
-                elif x < self.plot_width * 0.15:
-                    anchor = "start"
-                # Auto-hide synthesized value labels that would overlap an
-                # already-placed one. Explicit data_labels are left untouched so
-                # historical renders stay byte-for-byte identical.
-                if auto_hide:
-                    tw = calculate_text_dimensions(
-                        str(label_text), font=font_family, font_size=font_size
-                    ).width
-                    box = (
-                        x - tw / 2,
-                        ty - font_size / 2,
-                        x + tw / 2,
-                        ty + font_size / 2,
-                    )
-                    if any(
-                        box[0] < pb[2]
-                        and box[2] > pb[0]
-                        and box[1] < pb[3]
-                        and box[3] > pb[1]
-                        for pb in placed_boxes
-                    ):
-                        continue
-                    placed_boxes.append(box)
-                g.add_child(
-                    Text(
-                        text=str(label_text),
-                        x=x,
-                        y=ty,
-                        fill=fill,
-                        font_size=font_size,
-                        font_family=font_family,
-                        text_anchor=anchor,
-                        transform=f"translate({x},{ty}) scale(1,-1) translate({-x},{-ty})",
-                    )
-                )
-
-        return g
 
     @property
     def svg(self) -> str:

--- a/charted/charts/combo.py
+++ b/charted/charts/combo.py
@@ -108,13 +108,7 @@ class _SeriesProxy:
     _data_labels: list[str] | list[list[str]] | None = None
 
 
-# The type:ignore[misc] on the class line below is needed because ColumnChart
-# (via Chart) assigns x_axis/y_axis in __init__ without a class-level
-# annotation, so mypy cannot reconcile their type across this proxy's two
-# bases. _SeriesProxy supplies the concrete XAxis/YAxis annotations the proxy
-# actually uses; no annotation here resolves the indeterminate base-class types
-# without editing Chart.
-class _ColumnProxy(_SeriesProxy, ColumnChart):  # type: ignore[misc]
+class _ColumnProxy(_SeriesProxy, ColumnChart):
     """Column representation over a subset of combo series (side-by-side)."""
 
     def __init__(self, parent: "ComboChart", indices: list[int], y_axis: YAxis) -> None:


### PR DESCRIPTION
Second mixin-extraction pass, following #75. This continues splitting the chart base class into focused mixins so chart.py reads as composition rather than one long file.

Clusters pulled out this pass:

- Introspection: the describe machinery moves to ChartIntrospectionMixin.
- Reference and axis-label rendering: reference-line drawing and axis-label rendering move to ChartReferenceLayerMixin.
- Value-label rendering: the value-label methods move to ChartValueLabelMixin.
- Scale helpers: the scale helper methods move to ChartScaleMixin.

Line count: chart.py drops from 1636 to 961 lines in this pass, and from 2010 in the original file before the first extraction round.

The frozen visual baselines are byte-identical to main. git diff against origin/main over tests/baselines is empty, mypy passes under strict plus disallow_any_explicit (0 errors across 72 files), and pytest is 1396 passed with 6 known skips (1 default-theme contrast case, 5 tkinter tests that need a display).

The heavily coupled geometry and layout property cluster is left alone on purpose. Splitting it out is optional future work: it would be line-count cosmetics with low decoupling value, since those properties are too entangled with each other to separate cleanly.
