### PR TITLE
fix: geometric invariant bugs found by the property suite

### DIFF
--- a/charted/charts/axes.py
+++ b/charted/charts/axes.py
@@ -194,6 +194,13 @@ class Axis(G):
 
         if zero_index and min_value > 0:
             min_value = 0
+        # Symmetric clamp for an all-negative domain: pull the top of the range
+        # up to zero so the rendered domain still contains the zero baseline.
+        # Without this the domain is e.g. [-3, -1], and projecting the zero
+        # line / bar baseline lands at (0 - -3) / 2 = 1.5x the plot length,
+        # pushing gridlines, bars, markers and the line path outside the frame.
+        if zero_index and max_value < 0:
+            max_value = 0
 
         if not has_labels:
             if min_value < 0:

--- a/charted/charts/axes.py
+++ b/charted/charts/axes.py
@@ -211,6 +211,54 @@ class Axis(G):
 
         return AxisDimension(min_value, max_value, count)
 
+    # The largest number of gridline/tick entries the value axis will build for
+    # a denominator before we reject it as too fine and fall back to a
+    # nice-number step. The downstream halving loops thin this to <=10, so the
+    # cap only needs to stay well clear of the pathological millions-of-ticks
+    # region. ~50 is comfortably above any real layout and bounds memory.
+    _MAX_RAW_TICKS = 50
+    _TARGET_TICKS = 10
+
+    @classmethod
+    def _grid_step(
+        cls, value_range: float, denominators: Vector
+    ) -> float:
+        """Pick a tick step that does not explode the gridline list.
+
+        ``calculate_axis_values`` historically walked the common divisors of the
+        two endpoint magnitudes (largest first) and used the first step whose
+        list had more than 5 entries. For mismatched magnitudes (e.g. domain
+        (-1.0, 1e9)) the only common divisor is 1, which forces ~1e9 entries and
+        a MemoryError. When the finest available divisor would still produce
+        more than ``_MAX_RAW_TICKS`` entries, fall back to a clean ("nice")
+        number step computed from ``value_range / _TARGET_TICKS`` instead.
+        """
+        chosen: float | None = None
+        for denominator in reversed(denominators):
+            if denominator <= 0:
+                continue
+            if int(value_range / denominator) + 1 > 5:
+                chosen = denominator
+                break
+            chosen = denominator
+        if chosen is None or int(value_range / chosen) > cls._MAX_RAW_TICKS:
+            if value_range > 0:
+                nice = round_to_clean_number(value_range / cls._TARGET_TICKS)
+                if nice > 0:
+                    return nice
+            # Degenerate domain (no usable divisor and no range): a single tick.
+            return chosen if chosen is not None else 1.0
+        return chosen
+
+    @classmethod
+    def _grid_values(
+        cls, min_value: float, value_range: float, denominators: Vector
+    ) -> list[float]:
+        """Build the descending gridline-value list with a bounded tick step."""
+        step = cls._grid_step(value_range, denominators)
+        count = int(value_range / step)
+        return [min_value + (i * step) for i in reversed(range(count + 1))]
+
     @classmethod
     def calculate_axis_values(
         cls,
@@ -253,15 +301,9 @@ class Axis(G):
         if max_value > 0 and max_value < 1:
             max_value = 1
 
-        # Generate all potential grid line positions (full range)
-        all_values = []
-        for denominator in reversed(denominators):
-            count = int(value_range / denominator)
-            all_values = [
-                min_value + (i * denominator) for i in reversed(range(count + 1))
-            ]
-            if len(all_values) > 5:
-                break
+        # Generate all potential grid line positions (full range), with a tick
+        # step bounded so a mismatched-magnitude domain cannot explode the list.
+        all_values = cls._grid_values(min_value, value_range, denominators)
 
         # Preserve original axis range for grid lines
         original_min = all_values[-1]
@@ -380,20 +422,16 @@ class Axis(G):
                 zero_index=axis_values.zero_index,
             )
         )
-        # Store grid line values separately (full range, not filtered)
+        # Store grid line values separately (full range, not filtered). Reuse
+        # the same bounded-step helper as calculate_axis_values so a
+        # mismatched-magnitude domain cannot explode this list either.
         all_denominators = common_denominators(
             self.axis_dimension.min_value, self.axis_dimension.max_value
         )
         value_range = self.axis_dimension.max_value - self.axis_dimension.min_value
-        self._grid_line_values = []
-        for denominator in reversed(all_denominators):
-            count = int(value_range / denominator)
-            self._grid_line_values = [
-                self.axis_dimension.min_value + (i * denominator)
-                for i in reversed(range(count + 1))
-            ]
-            if len(self._grid_line_values) > 5:
-                break
+        self._grid_line_values = self._grid_values(
+            self.axis_dimension.min_value, value_range, all_denominators
+        )
         # Reduce grid lines if too many
         while len(self._grid_line_values) > 10 and 0 not in self._grid_line_values:
             self._grid_line_values = [
@@ -566,6 +604,47 @@ class XAxis(Axis):
         # Minor lines first so the heavier major lines render on top.
         return G().add_children(minor_path, major_path)
 
+    @staticmethod
+    def _non_overlapping_indices(
+        coordinates: list[float],
+        labels: list[MeasuredText],
+        dx: float,
+    ) -> set[int]:
+        """Pick label indices whose centred boxes do not overlap their neighbour.
+
+        Walks the labels in left-to-right order and keeps an index only when its
+        centred box clears the previously kept label's box. The first and last
+        labels are always retained: if the final label collides with the last
+        kept middle label, that middle one is dropped instead so the axis range
+        stays labelled. Rotated axes are not centred this way, so callers only
+        rely on this for the horizontal case; it is a no-op when nothing
+        collides, leaving fitting axes byte-for-byte unchanged.
+        """
+        n = len(labels)
+        if n <= 1:
+            return set(range(n))
+        order = sorted(range(n), key=lambda i: coordinates[i])
+
+        def box(i: int) -> tuple[float, float]:
+            centre = coordinates[i] + dx
+            half = labels[i].width / 2
+            return centre - half, centre + half
+
+        kept: list[int] = [order[0]]
+        last_right = box(order[0])[1]
+        for i in order[1:-1]:
+            left, right = box(i)
+            if left >= last_right - 1.0:
+                kept.append(i)
+                last_right = right
+        if len(order) > 1:
+            last = order[-1]
+            left, right = box(last)
+            while len(kept) > 1 and box(kept[-1])[1] > left + 1.0:
+                kept.pop()
+            kept.append(last)
+        return set(kept)
+
     @property
     def axis_labels(self) -> G:
         theme = getattr(self.parent, "theme", None)
@@ -604,10 +683,24 @@ class XAxis(Axis):
         # middle so labels stop overlapping into a smear.
         stride = self._label_stride(len(all_labels))
         last_index = len(all_labels) - 1
+        # Width-aware overlap pass. Value-axis numeric labels (e.g. a
+        # mismatched-magnitude domain like (-4e8, 1e9)) are not ordinal, so the
+        # count-based stride leaves them all in place even when adjacent wide
+        # labels collide. Drop the indices whose centred box would overlap the
+        # previous kept label; this only ever removes labels, so an axis whose
+        # labels already fit keeps every one and renders byte-for-byte the same.
+        # The centred-box overlap model only describes horizontal labels; rotated
+        # labels pivot off their tick and are handled by the rotation angle, so
+        # only drop overlaps when the axis is not rotated.
+        keep: set[int] | None = None
+        if rotation_angle <= 0:
+            keep = self._non_overlapping_indices(coordinates, all_labels, dx)
         left_pad = self.parent.left_padding
         chart_width = getattr(self.parent, "width", None)
         for index, (x, label) in enumerate(zip(coordinates, all_labels)):
             if stride > 1 and index not in (0, last_index) and index % stride != 0:
+                continue
+            if keep is not None and index not in keep:
                 continue
             x = x + dx
             if rotation_angle > 0:

--- a/charted/charts/axes.py
+++ b/charted/charts/axes.py
@@ -704,8 +704,13 @@ class XAxis(Axis):
                 continue
             x = x + dx
             if rotation_angle > 0:
+                # Shift the rotated label left by roughly one character width so
+                # it pivots from its right edge. An empty label has no
+                # characters (and zero width), so there is nothing to shift:
+                # guard the division to avoid a ZeroDivisionError on len('').
+                char_shift = label.width / len(label.text) if label.text else 0.0
                 transformations = [
-                    translate(label.width / len(label.text) * -1, 0),
+                    translate(char_shift * -1, 0),
                     rotate(rotation_angle, x, y),
                 ]
             else:

--- a/charted/charts/axes.py
+++ b/charted/charts/axes.py
@@ -605,30 +605,77 @@ class XAxis(Axis):
         return G().add_children(minor_path, major_path)
 
     @staticmethod
+    def _rotated_x_span(
+        coordinate: float,
+        label: MeasuredText,
+        rotation_angle: float,
+    ) -> tuple[float, float]:
+        """Return a rotated label's projected ``(left, right)`` x-extent.
+
+        Rotated tick labels pivot about their tick at ``(coordinate, plot_height)``
+        and are shifted left by one character width first (so they pivot off the
+        right edge), exactly as :attr:`axis_labels` renders them. The box grows
+        upward from the baseline by the label height. Projecting the four rotated
+        corners onto the x axis gives the horizontal footprint the next label has
+        to clear. This mirrors the absolute geometry the geometric-invariant tests
+        recompute from the rendered SVG, so the drop decision matches what is
+        actually painted.
+        """
+        char_shift = label.width / len(label.text) if label.text else 0.0
+        # Box corners in the rotation pivot's frame (pivot at x=0). The text is
+        # start-anchored at ``-char_shift`` and the baseline sits at the pivot, so
+        # the box rises to ``-height``.
+        left_x = -char_shift
+        right_x = -char_shift + label.width
+        top_y = -label.height
+        bottom_y = 0.0
+        rad = math.radians(rotation_angle)
+        cos, sin = math.cos(rad), math.sin(rad)
+        # SVG rotate maps (px, py) -> (px*cos - py*sin, ...); we only need the
+        # x component to bound the horizontal footprint.
+        xs = [
+            px * cos - py * sin
+            for px in (left_x, right_x)
+            for py in (top_y, bottom_y)
+        ]
+        return coordinate + min(xs), coordinate + max(xs)
+
+    @classmethod
     def _non_overlapping_indices(
+        cls,
         coordinates: list[float],
         labels: list[MeasuredText],
         dx: float,
+        rotation_angle: float = 0.0,
     ) -> set[int]:
-        """Pick label indices whose centred boxes do not overlap their neighbour.
+        """Pick label indices whose boxes do not overlap their kept neighbour.
 
         Walks the labels in left-to-right order and keeps an index only when its
-        centred box clears the previously kept label's box. The first and last
-        labels are always retained: if the final label collides with the last
+        x-footprint clears the previously kept label's. For an unrotated axis the
+        footprint is the centred label box; for a rotated axis it is the rotated
+        label's projected x-extent (see :meth:`_rotated_x_span`). The first and
+        last labels are always retained: if the final label collides with the last
         kept middle label, that middle one is dropped instead so the axis range
-        stays labelled. Rotated axes are not centred this way, so callers only
-        rely on this for the horizontal case; it is a no-op when nothing
-        collides, leaving fitting axes byte-for-byte unchanged.
+        stays labelled. The pass only ever removes labels, so an axis whose labels
+        already fit keeps every one and renders byte-for-byte the same.
         """
         n = len(labels)
         if n <= 1:
             return set(range(n))
         order = sorted(range(n), key=lambda i: coordinates[i])
 
-        def box(i: int) -> tuple[float, float]:
-            centre = coordinates[i] + dx
-            half = labels[i].width / 2
-            return centre - half, centre + half
+        if rotation_angle > 0:
+
+            def box(i: int) -> tuple[float, float]:
+                return cls._rotated_x_span(
+                    coordinates[i] + dx, labels[i], rotation_angle
+                )
+        else:
+
+            def box(i: int) -> tuple[float, float]:
+                centre = coordinates[i] + dx
+                half = labels[i].width / 2
+                return centre - half, centre + half
 
         kept: list[int] = [order[0]]
         last_right = box(order[0])[1]
@@ -686,21 +733,21 @@ class XAxis(Axis):
         # Width-aware overlap pass. Value-axis numeric labels (e.g. a
         # mismatched-magnitude domain like (-4e8, 1e9)) are not ordinal, so the
         # count-based stride leaves them all in place even when adjacent wide
-        # labels collide. Drop the indices whose centred box would overlap the
+        # labels collide. Drop the indices whose footprint would overlap the
         # previous kept label; this only ever removes labels, so an axis whose
         # labels already fit keeps every one and renders byte-for-byte the same.
-        # The centred-box overlap model only describes horizontal labels; rotated
-        # labels pivot off their tick and are handled by the rotation angle, so
-        # only drop overlaps when the axis is not rotated.
-        keep: set[int] | None = None
-        if rotation_angle <= 0:
-            keep = self._non_overlapping_indices(coordinates, all_labels, dx)
+        # Horizontal axes use the centred label box; rotated axes use the rotated
+        # label's projected x-extent, since a steep rotation still leaves a wide
+        # label spanning enough of the x axis to collide with its neighbour.
+        keep = self._non_overlapping_indices(
+            coordinates, all_labels, dx, rotation_angle
+        )
         left_pad = self.parent.left_padding
         chart_width = getattr(self.parent, "width", None)
         for index, (x, label) in enumerate(zip(coordinates, all_labels)):
             if stride > 1 and index not in (0, last_index) and index % stride != 0:
                 continue
-            if keep is not None and index not in keep:
+            if index not in keep:
                 continue
             x = x + dx
             if rotation_angle > 0:

--- a/charted/utils/layout_engine.py
+++ b/charted/utils/layout_engine.py
@@ -160,6 +160,21 @@ class LayoutEngine:
         """
         base = self.v_padding * self.height
 
+        # Bottom-axis tick labels (the category labels of a column chart and the
+        # numeric value-axis labels of a horizontal bar chart) are drawn
+        # DEFAULT_PADDING below the plot bottom, so their baseline sits at
+        # (height - bottom_padding + DEFAULT_PADDING). When the fractional
+        # v_padding band is thinner than DEFAULT_PADDING (small canvases, roughly
+        # height < 360px) that baseline drops below the viewBox and the labels
+        # overflow the bottom edge by a few pixels. The horizontal bar chart's
+        # value labels are not carried in x_labels, so reserve the band
+        # unconditionally. Larger canvases already have a v_padding band >=
+        # DEFAULT_PADDING, so their layout (including every 500px baseline
+        # fixture) is byte-for-byte unchanged.
+        from ..constants import DEFAULT_PADDING
+
+        base = max(base, DEFAULT_PADDING)
+
         # Reserve a band below the plot for a bottom-placed legend. The legend
         # is drawn at the chart's bottom edge, so the band must clear the
         # x-axis tick labels. Those labels sit DEFAULT_PADDING below the plot

--- a/tests/charts/test_axes.py
+++ b/tests/charts/test_axes.py
@@ -1,8 +1,16 @@
 """Test suite for axis rendering (XAxis, YAxis)."""
 
+import math
+
 import pytest
 
 from charted.charts.axes import XAxis, YAxis
+from charted.utils.types import MeasuredText
+
+
+def _mt(text: str, width: float, height: float = 9.0) -> MeasuredText:
+    """Build a MeasuredText with explicit dimensions for overlap tests."""
+    return MeasuredText(text=text, width=width, height=height)
 
 
 class MockParent:
@@ -215,3 +223,104 @@ class TestYAxisSadPath:
         labels = axis.labels
         # Labels should be formatted
         assert len(labels) > 0
+
+
+class TestNonOverlappingIndices:
+    """Direct unit tests for ``XAxis._non_overlapping_indices``.
+
+    This pass decides which tick labels survive a width-aware overlap drop.
+    A silent bug here would quietly remove labels users need, so the kept set
+    is pinned directly rather than only through the geometric-invariant suite.
+    """
+
+    def test_fitting_labels_keep_every_index(self):
+        """Well-spaced labels never collide, so all are kept."""
+        coords = [0.0, 50.0, 100.0, 150.0]
+        labels = [_mt("a", 10.0) for _ in coords]
+        keep = XAxis._non_overlapping_indices(coords, labels, dx=0.0)
+        assert keep == {0, 1, 2, 3}
+
+    def test_single_and_empty(self):
+        """Zero or one label is always fully kept (no neighbour to clear)."""
+        assert XAxis._non_overlapping_indices([], [], dx=0.0) == set()
+        assert XAxis._non_overlapping_indices([5.0], [_mt("a", 99.0)], dx=0.0) == {0}
+
+    def test_colliding_middles_drop_to_minimal_set(self):
+        """Wide labels packed tightly keep first, last, and minimal middles.
+
+        Boxes are centred half-widths: at width 40 on a 20px pitch every
+        neighbour overlaps, so the greedy pass keeps index 0, the first middle
+        that clears it (2), and the forced final (4).
+        """
+        coords = [0.0, 20.0, 40.0, 60.0, 80.0]
+        labels = [_mt(str(i), 40.0) for i in range(5)]
+        keep = XAxis._non_overlapping_indices(coords, labels, dx=0.0)
+        assert keep == {0, 2, 4}
+
+    def test_first_and_last_always_retained(self):
+        """Even with everything colliding, the axis range stays labelled."""
+        coords = [0.0, 5.0, 10.0, 15.0]
+        labels = [_mt(str(i), 80.0) for i in range(4)]
+        keep = XAxis._non_overlapping_indices(coords, labels, dx=0.0)
+        assert 0 in keep
+        assert 3 in keep
+
+    def test_chain_collision_drops_only_the_blocker(self):
+        """A final label colliding with the last middle pops just that middle.
+
+        Coords/widths are chosen so the greedy pass keeps {0, 1, 2} and then the
+        forced final (3) overlaps only the last kept middle (2). The pass must
+        drop index 2 and keep index 1, not cascade further.
+        """
+        coords = [0.0, 30.0, 55.0, 60.0]
+        labels = [_mt(str(i), 20.0) for i in range(4)]
+        keep = XAxis._non_overlapping_indices(coords, labels, dx=0.0)
+        assert keep == {0, 1, 3}
+
+    def test_dx_shift_does_not_change_relative_overlap(self):
+        """A uniform dx offset shifts every box equally; the kept set is stable."""
+        coords = [0.0, 20.0, 40.0, 60.0, 80.0]
+        labels = [_mt(str(i), 40.0) for i in range(5)]
+        base = XAxis._non_overlapping_indices(coords, labels, dx=0.0)
+        shifted = XAxis._non_overlapping_indices(coords, labels, dx=17.0)
+        assert base == shifted == {0, 2, 4}
+
+    def test_rotated_span_projects_full_footprint(self):
+        """The rotated x-span matches the projected corners of the tilted box."""
+        label = _mt("AB", 20.0, height=10.0)
+        left, right = XAxis._rotated_x_span(100.0, label, rotation_angle=30.0)
+        char_shift = label.width / len(label.text)  # 10.0
+        rad = math.radians(30.0)
+        cos, sin = math.cos(rad), math.sin(rad)
+        xs = [
+            px * cos - py * sin
+            for px in (-char_shift, -char_shift + label.width)
+            for py in (-label.height, 0.0)
+        ]
+        assert left == pytest.approx(100.0 + min(xs))
+        assert right == pytest.approx(100.0 + max(xs))
+
+    def test_rotated_fitting_labels_keep_every_index(self):
+        """Rotated labels that clear their neighbour are all kept."""
+        coords = [0.0, 200.0, 400.0]
+        labels = [_mt("x", 8.0, height=9.0) for _ in coords]
+        keep = XAxis._non_overlapping_indices(
+            coords, labels, dx=0.0, rotation_angle=45.0
+        )
+        assert keep == {0, 1, 2}
+
+    def test_rotated_colliding_labels_drop(self):
+        """Steeply rotated wide labels on a tight pitch collide and are thinned.
+
+        At 60 degrees the projected footprint of each 60px-wide label spans well
+        past the 30px pitch, so the pass keeps first, last, and a minimal middle
+        rather than the overlapping full set.
+        """
+        coords = [0.0, 30.0, 60.0, 90.0, 120.0]
+        labels = [_mt("wide" + str(i), 60.0, height=12.0) for i in range(5)]
+        keep = XAxis._non_overlapping_indices(
+            coords, labels, dx=0.0, rotation_angle=60.0
+        )
+        assert keep != {0, 1, 2, 3, 4}
+        assert 0 in keep and 4 in keep
+        assert len(keep) < 5

--- a/tests/test_geometric_invariants.py
+++ b/tests/test_geometric_invariants.py
@@ -26,11 +26,11 @@ Calibration notes
 The render-level invariants (3-5) are checked at *realistic* canvas sizes
 (>= 400 px, charted's default is 500x500) with non-empty labels. Text-label
 containment is excluded from the in-frame check: charted does not clip long
-labels, an open item in its own TODO.md (#45). Four genuine bugs surfaced
-during calibration are documented and pinned by the ``test_known_bug_*`` cases
-at the end of this module (all-negative LineChart and BarChart projection, an
-empty-label ZeroDivisionError, and small-canvas bottom-label overflow) rather
-than silently weakening the main invariants. We do NOT fix charted here.
+labels, an open item in its own TODO.md (#45). Several genuine bugs surfaced
+during calibration (all-negative projection, mixed-magnitude tick explosion,
+an empty-label ZeroDivisionError, small-canvas bottom-label overflow); they
+have since been fixed and are guarded by the regression cases at the end of
+this module.
 """
 
 from __future__ import annotations
@@ -746,18 +746,16 @@ def _text_in_frame_violations(svg: str, tol: float = 1.0) -> list[str]:
     return out
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "GEOMETRY/LAYOUT BUG: on small canvases (height < ~400px) charted's "
-        "fixed bottom-axis margin does not shrink, so the bottom value-axis "
-        "tick labels overflow the viewBox by a few pixels. Repro: "
-        "BarChart([5,10,15], labels=['a','b','c'], width=320, height=240) -> "
-        "bottom tick-label baseline lands at absolute y=246 (viewBox bottom is "
-        "240). Related to TODO.md #45 (long-label overflow)."
-    ),
-)
-def test_known_bug_small_canvas_bottom_labels_overflow() -> None:
+def test_small_canvas_bottom_labels_stay_in_frame() -> None:
+    """Regression: small-canvas bottom tick labels stay inside the viewBox.
+
+    The bottom-axis margin used to be a flat fraction of the height, so on a
+    short canvas it shrank below the DEFAULT_PADDING gap the tick labels are
+    drawn at and the bottom labels spilled past the viewBox (baseline at y=246
+    on a 240px-tall chart). bottom_padding now reserves at least DEFAULT_PADDING
+    for the tick-label band, keeping them framed. Larger canvases (the 500px
+    baseline fixtures) already exceed that, so their layout is unchanged.
+    """
     values: list[float] = [5.0, 10.0, 15.0]
     svg = str(BarChart(values, labels=["a", "b", "c"], width=320, height=240).to_svg())
     violations = _text_in_frame_violations(svg)

--- a/tests/test_geometric_invariants.py
+++ b/tests/test_geometric_invariants.py
@@ -119,57 +119,16 @@ _positive_float = st.one_of(
 )
 
 
-def _axis_tick_list_bounded(values: list[float], limit: int = 50_000) -> bool:
-    """Mirror the grid-list size Axis.calculate_axis_values would build.
-
-    Known charted bug (#5, see test_known_bug_mixed_magnitude_tick_explosion):
-    a mixed-sign domain with mismatched magnitudes forces the tick step down to
-    the largest common divisor of the endpoint magnitudes, so the value-axis
-    list comprehension materialises O(range/step) floats. The minimal repro
-    AreaChart([-1.0, 1e9], labels=["a", "b"], width=500, height=500).to_svg()
-    raises MemoryError trying to build a billion-element list. Until that is
-    fixed, keep generated inputs out of the explosive region; this predictor
-    replicates the size computation without allocating.
-    """
-    from charted.charts.axes import Axis
-    from charted.utils.helpers import common_denominators
-
-    for has_labels in (True, False):
-        for zero_index in (True, False):
-            try:
-                axd = Axis.calculate_axis_dimensions(
-                    data=[values], has_labels=has_labels, zero_index=zero_index
-                )
-                denominators = common_denominators(axd.min_value, axd.max_value)
-            except (ValueError, ZeroDivisionError, OverflowError):
-                continue
-            if not denominators:
-                continue
-            value_range = axd.value_range if axd.value_range >= 2 else 1
-            # calculate_axis_values builds a list per denominator (largest
-            # first) and stops after the first one longer than 5 entries; the
-            # biggest list it materialises is exactly that breaking list.
-            built = 0
-            for denominator in reversed(denominators):
-                built = int(value_range / denominator)
-                if built + 1 > 5:
-                    break
-            if built > limit:
-                return False
-    return True
-
-
 def value_lists(
     min_size: int = 1, max_size: int = 60
 ) -> st.SearchStrategy[list[float]]:
     """Lists of adversarial floats: mixed signs, tiny/huge magnitudes, zeros.
 
-    Filtered through _axis_tick_list_bounded to stay clear of the known
-    mixed-magnitude tick-explosion bug (charted bug #5).
+    Mixed-magnitude domains (e.g. (-1.0, 1e9)) used to explode the value-axis
+    tick list and were filtered out; the axis now bounds its tick step, so the
+    full adversarial range is exercised directly.
     """
-    return st.lists(_adversarial_float, min_size=min_size, max_size=max_size).filter(
-        _axis_tick_list_bounded
-    )
+    return st.lists(_adversarial_float, min_size=min_size, max_size=max_size)
 
 
 def equal_value_lists(max_size: int = 30) -> st.SearchStrategy[list[float]]:
@@ -294,16 +253,10 @@ def _memory_ceiling() -> Iterator[None]:
     """Cap this test process's address space at 192 MiB.
 
     The suite's honest peak is ~60 MiB; the headroom only exists so a leaking
-    example dies fast instead of slow.
-
-    The mixed-magnitude tick explosion (charted bug #5, see
-    test_known_bug_mixed_magnitude_tick_explosion) makes the axis code attempt
-    multi-gigabyte allocations. The _axis_tick_list_bounded strategy filter
-    catches the inputs it can predict, but the duplicated grid-line loop in
-    Axis.values (axes.py:385) is reached through chart-specific axis wiring the
-    predictor does not see. The rlimit turns any leak-through into a clean
-    in-process MemoryError, which _render_or_skip converts into a dropped
-    example, instead of an OOM-killed host.
+    example dies fast instead of slow. The mixed-magnitude tick explosion that
+    once forced multi-gigabyte allocations is fixed (the axis now bounds its
+    tick step), so this ceiling is just cheap host insurance against any future
+    regression that tries to allocate without bound.
     """
     ceiling = 192 * 1024**2
     soft, hard = resource.getrlimit(resource.RLIMIT_AS)
@@ -319,26 +272,16 @@ def _render_or_skip(make: object) -> str | None:
     """Render via ``make()``; return SVG, or None if charted rejected the input.
 
     Any non-charted exception propagates and fails the test (the clean-failure
-    invariant). MemoryError is treated as the known tick-explosion bug (#5)
-    and drops the example rather than failing every in-frame test on inputs
-    the bug already owns.
+    invariant).
     """
     assert callable(make)
     try:
         return str(make())
     except ACCEPTABLE_ERRORS:
         return None
-    except MemoryError:
-        # Charted bug #5: mixed-magnitude tick explosion (pinned separately by
-        # test_known_bug_mixed_magnitude_tick_explosion).
-        assume(False)
-        return None  # pragma: no cover - assume(False) always raises
 
 
 # All chart builders keyed by name, parameterised on a single value list.
-# LineChart is restricted to non-all-negative data via _line_safe (or an inline
-# guard) where it is exercised, because all-negative line projection is a known
-# bug pinned by test_known_bug_line_all_negative_overflows_top.
 ALL_CHART_BUILDERS: dict[str, object] = {
     "BarChart": lambda v: BarChart(v, labels=[str(i) for i in range(len(v))]),
     "ColumnChart": lambda v: ColumnChart(v, labels=[str(i) for i in range(len(v))]),
@@ -365,11 +308,6 @@ ALL_CHART_BUILDERS: dict[str, object] = {
 def test_well_formed_and_finite(values: list[float], name: str) -> None:
     builder = ALL_CHART_BUILDERS[name]
     assert callable(builder)
-    # LineChart projects all-negative series above the frame (known bug, see
-    # the xfail test); keep it out of the well-formed/finite sweep so this test
-    # exercises the contract that does hold for every type.
-    if name == "LineChart" and values and all(v < 0 for v in values):
-        values = [abs(v) for v in values]
     svg = _render_or_skip(lambda: builder(values).to_svg())
     assume(svg is not None)
     assert svg is not None
@@ -382,23 +320,10 @@ def test_well_formed_and_finite(values: list[float], name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _line_safe(
-    data: tuple[list[float], list[str], tuple[float, float]],
-) -> tuple[list[float], list[str], tuple[float, float]]:
-    """Replace an all-negative line series with its magnitudes (known bug)."""
-    values, labels, dims = data
-    if values and all(v < 0 for v in values):
-        values = [abs(v) for v in values]
-    return values, labels, dims
-
-
 @SETTINGS
 @given(data=labeled_values())
 def test_bar_in_frame(data: tuple[list[float], list[str], tuple[float, float]]) -> None:
-    # BarChart (horizontal) places its zero gridline far outside the plot for an
-    # all-negative series, the same projection bug as LineChart. Exclude that
-    # case here; it is pinned by test_known_bug_all_negative_overflows below.
-    values, labels, (w, h) = _line_safe(data)
+    values, labels, (w, h) = data
     svg = _render_or_skip(
         lambda: BarChart(values, labels=labels, width=w, height=h).to_svg()
     )
@@ -426,7 +351,7 @@ def test_column_in_frame(
 def test_line_in_frame(
     data: tuple[list[float], list[str], tuple[float, float]],
 ) -> None:
-    values, labels, (w, h) = _line_safe(data)
+    values, labels, (w, h) = data
     svg = _render_or_skip(
         lambda: LineChart(values, labels=labels, width=w, height=h).to_svg()
     )
@@ -458,20 +383,7 @@ def test_area_in_frame(
 def test_scatter_in_frame(
     xs: list[float], data: st.DataObject, dims: tuple[float, float]
 ) -> None:
-    # All-negative x series project markers far outside the frame, the same
-    # projection fault as the LineChart/BarChart cases; pinned by
-    # test_known_bug_scatter_all_negative_x_out_of_frame.
-    if xs and all(v < 0 for v in xs):
-        xs = [abs(v) for v in xs]
-    ys = data.draw(
-        st.lists(_adversarial_float, min_size=len(xs), max_size=len(xs)).filter(
-            _axis_tick_list_bounded
-        )
-    )
-    # The y axis has the same all-negative projection fault (gridline drawn at
-    # y=-450 for ys=[-2.0]); also pinned by the scatter known-bug test.
-    if ys and all(v < 0 for v in ys):
-        ys = [abs(v) for v in ys]
+    ys = data.draw(st.lists(_adversarial_float, min_size=len(xs), max_size=len(xs)))
     w, h = dims
     svg = _render_or_skip(lambda: ScatterChart(xs, ys, width=w, height=h).to_svg())
     assume(svg is not None)
@@ -567,7 +479,7 @@ def test_column_no_label_overlap(
 def test_line_no_label_overlap(
     data: tuple[list[float], list[str], tuple[float, float]],
 ) -> None:
-    values, labels, (w, h) = _line_safe(data)
+    values, labels, (w, h) = data
     svg = _render_or_skip(
         lambda: LineChart(values, labels=labels, width=w, height=h).to_svg()
     )
@@ -586,9 +498,7 @@ def test_line_no_label_overlap(
 def test_bar_bars_in_plot(
     data: tuple[list[float], list[str], tuple[float, float]],
 ) -> None:
-    # All-negative bars project past the plot right edge (same root cause as the
-    # gridline bug, pinned by test_known_bug_bar_all_negative_gridline_overflows).
-    values, labels, (w, h) = _line_safe(data)
+    values, labels, (w, h) = data
     svg = _render_or_skip(
         lambda: BarChart(values, labels=labels, width=w, height=h).to_svg()
     )
@@ -754,9 +664,8 @@ def test_log_scale_monotonic_and_ticks(lo: float, factor: float, length: float) 
 def test_clean_failure_no_unexpected_exception(values: list[float], name: str) -> None:
     builder = ALL_CHART_BUILDERS[name]
     assert callable(builder)
-    # _render_or_skip propagates anything that is neither a documented charted
-    # rejection nor the pinned tick-explosion MemoryError (bug #5), so an
-    # unexpected exception type still fails this test.
+    # _render_or_skip propagates anything that is not a documented charted
+    # rejection, so an unexpected exception type still fails this test.
     svg = _render_or_skip(lambda: builder(values).to_svg())
     if svg is None:
         return
@@ -766,7 +675,7 @@ def test_clean_failure_no_unexpected_exception(values: list[float], name: str) -
 
 
 # ---------------------------------------------------------------------------
-# Documented known bugs (pinned, not fixed)
+# Regression guards for bugs the property suite surfaced (now fixed)
 # ---------------------------------------------------------------------------
 
 
@@ -860,24 +769,21 @@ def test_known_bug_small_canvas_bottom_labels_overflow() -> None:
     assert not violations, f"labels overflow small canvas: {violations}"
 
 
-def test_known_bug_mixed_magnitude_tick_explosion() -> None:
-    """MEMORY BUG: mixed-sign domains with mismatched magnitudes explode the
-    value axis. calculate_axis_values picks the tick step from the common
-    divisors of the two endpoint magnitudes (axes.py:254), so a domain like
-    (-1.0, 1e9) is forced to step=1.0 and the grid-value list comprehension
-    materialises ~1e9 floats. Repro (DO NOT run unguarded, it OOMs the host):
+def test_mixed_magnitude_domain_renders_without_exploding() -> None:
+    """Regression: a mismatched-magnitude domain no longer explodes the axis.
 
-        AreaChart([-1.0, 1e9], labels=["a", "b"], width=500, height=500).to_svg()
-
-    -> MemoryError. Found because the unbounded property suite OOM'd a 2GB
-    rlimit (and, before that, the operator's machine). Unlike the other four
-    known-bug pins this one cannot be a plain xfail: executing the repro
-    allocates until the kernel intervenes. Instead it pins the bug through the
-    same size predictor the strategies use as a generation guard, which fails
-    (and flags this test for removal) once the axis code stops over-allocating.
+    calculate_axis_values used to pick the tick step from the common divisors
+    of the two endpoint magnitudes, so a domain like (-1.0, 1e9) was forced to
+    step=1.0 and the grid-value list comprehension materialised ~1e9 floats,
+    raising MemoryError. The axis now caps the raw tick count and falls back to
+    a nice-number step, so the repro renders quickly inside a small memory cap.
+    Runs under the module's 192 MiB ceiling; explosion would re-raise here.
     """
-    assert not _axis_tick_list_bounded([-1.0, 1e9], limit=100_000_000), (
-        "predicted tick list for (-1.0, 1e9) is no longer explosive: the axis "
-        "bug looks fixed. Delete this pin and the _axis_tick_list_bounded "
-        "strategy filters so the suite covers mixed-magnitude domains again."
-    )
+    import time
+
+    start = time.monotonic()
+    svg = str(AreaChart([-1.0, 1e9], labels=["a", "b"], width=500, height=500).to_svg())
+    elapsed = time.monotonic() - start
+    _assert_well_formed(svg)
+    _assert_in_frame(svg)
+    assert elapsed < 1.0, f"mixed-magnitude render took {elapsed:.2f}s (expected <1s)"

--- a/tests/test_geometric_invariants.py
+++ b/tests/test_geometric_invariants.py
@@ -770,17 +770,15 @@ def test_clean_failure_no_unexpected_exception(values: list[float], name: str) -
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "GEOMETRY BUG: LineChart with an all-negative series projects the data "
-        "path above the top of the viewBox. Repro: LineChart([-2.0, -3.0, -1.0], "
-        "labels=['a','b','c'], width=500, height=500) -> line path bbox top y ~= "
-        "-200 (viewBox top is 0). Mixed-sign and all-positive series render "
-        "correctly; AreaChart clamps and is unaffected."
-    ),
-)
-def test_known_bug_line_all_negative_overflows_top() -> None:
+def test_line_all_negative_stays_in_frame() -> None:
+    """Regression: an all-negative LineChart series stays inside the viewBox.
+
+    Previously the projection left the rendered domain at e.g. [-3, -1] with no
+    zero baseline, so the data path was lifted above the top of the frame
+    (path bbox top y ~= -200 on a 500x500 canvas). calculate_axis_dimensions
+    now clamps an all-negative domain's max up to zero (mirroring the existing
+    min-to-zero clamp), so the zero baseline is back inside the plot.
+    """
     svg = str(
         LineChart(
             [-2.0, -3.0, -1.0], labels=["a", "b", "c"], width=500, height=500
@@ -789,37 +787,27 @@ def test_known_bug_line_all_negative_overflows_top() -> None:
     _assert_in_frame(svg)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "GEOMETRY BUG: horizontal BarChart with an all-negative series places "
-        "both its zero gridline and the bar rect far to the right of the plot. "
-        "Repro: BarChart([-2.0], labels=[''], width=500, height=500) -> gridline "
-        "path 'M900 0 v450' at x~=925 (viewBox is 500 wide); BarChart([-16.0], "
-        "labels=['a']) -> bar rect x-extent 475..1802 vs plot right edge 475. "
-        "With [-1e9] the gridline is at x~=4.5e11. Same projection fault as the "
-        "LineChart case. ColumnChart and mixed-sign data are unaffected."
-    ),
-)
-def test_known_bug_bar_all_negative_gridline_overflows() -> None:
+def test_bar_all_negative_gridline_in_frame() -> None:
+    """Regression: an all-negative horizontal BarChart stays inside the viewBox.
+
+    Previously the rendered domain stayed at e.g. [-3, -1] (no zero baseline),
+    so the zero gridline and the bar rect projected far to the right of the
+    plot (gridline at x~=925 on a 500-wide canvas, x~=4.5e11 for [-1e9]). The
+    all-negative max-to-zero clamp in calculate_axis_dimensions keeps both the
+    gridline and the bar inside the frame.
+    """
     svg = str(BarChart([-2.0], labels=[""], width=500, height=500).to_svg())
     _assert_in_frame(svg)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "GEOMETRY BUG: ScatterChart with an all-negative series on either axis "
-        "projects geometry far outside the plot. Repro (x): "
-        "ScatterChart([-16.0], [0.0], width=500, height=500) -> marker circle "
-        "at x~=1724 (viewBox is 500 wide). Repro (y): ScatterChart([0.0], "
-        "[-2.0], width=500, height=500) -> gridline path 'M0 -450' above the "
-        "frame. Third member of the all-negative projection family (LineChart "
-        "top overflow, BarChart gridline overflow); mixed-sign and "
-        "all-positive series render correctly."
-    ),
-)
-def test_known_bug_scatter_all_negative_x_out_of_frame() -> None:
+def test_scatter_all_negative_axis_in_frame() -> None:
+    """Regression: an all-negative ScatterChart axis stays inside the viewBox.
+
+    Previously an all-negative x or y series left the domain with no zero
+    baseline, projecting the marker (x~=1724) or the zero gridline (y=-450)
+    outside the frame. The all-negative clamp in calculate_axis_dimensions
+    fixes both axes; this checks the x case (the y case is symmetric).
+    """
     svg = str(ScatterChart([-16.0], [0.0], width=500, height=500).to_svg())
     _assert_in_frame(svg)
 

--- a/tests/test_geometric_invariants.py
+++ b/tests/test_geometric_invariants.py
@@ -721,23 +721,18 @@ def test_scatter_all_negative_axis_in_frame() -> None:
     _assert_in_frame(svg)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "CLEAN-FAILURE BUG: an empty-string axis label crashes the rotated "
-        "x-axis with an uncaught ZeroDivisionError instead of rendering or "
-        "raising a charted error. axes.py:608 computes "
-        "'label.width / len(label.text)' which divides by len('')==0 once the "
-        "axis is dense enough to rotate labels. Repro: "
-        "ColumnChart([5.0]*20, labels=['abcdef']*10 + ['']*10, width=500, "
-        "height=500). Affects ColumnChart and LineChart (rotated bottom axis); "
-        "BarChart (horizontal) is unaffected."
-    ),
-    raises=ZeroDivisionError,
-)
-def test_known_bug_empty_label_zero_division() -> None:
+def test_empty_label_does_not_crash_rotated_axis() -> None:
+    """Regression: an empty-string axis label no longer crashes a rotated axis.
+
+    A dense ordinal axis rotates its labels and shifted each one left by
+    ``label.width / len(label.text)``. An empty label made that ``len('')==0``,
+    raising an uncaught ZeroDivisionError. The shift is now guarded (an empty
+    label has zero width and nothing to shift). Repro: ColumnChart with a mix
+    of populated and empty labels dense enough to trigger rotation.
+    """
     labels = ["abcdef"] * 10 + [""] * 10
-    ColumnChart([5.0] * 20, labels=labels, width=500, height=500).to_svg()
+    svg = str(ColumnChart([5.0] * 20, labels=labels, width=500, height=500).to_svg())
+    _assert_well_formed(svg)
 
 
 def _text_in_frame_violations(svg: str, tol: float = 1.0) -> list[str]:


### PR DESCRIPTION
Stacked on #81 (`invariant-suite`). These are the four root causes (six symptoms) the geometric-invariant property suite pinned, plus a follow-up fix for rotated-axis label overlap found in review. Each is fixed, and the corresponding pins are converted from strict-xfail into plain regression tests. The suite now ends fully green with zero remaining bug xfails.

## 1. All-negative axis projection (3 symptoms, one root)

`charts/axes.py` `calculate_axis_dimensions` only clamped the domain minimum to zero for all-positive data. An all-negative series left the rendered domain as e.g. `[-3, -1]` with no zero baseline, so the zero line, bar baseline, scatter markers and line path all projected outside the plot.

- Before: `BarChart([-2.0])` zero gridline at x≈925 on a 500px canvas (x≈4.5e11 for `[-1e9]`); `LineChart([-2,-3,-1])` path lifted ~200px above the top edge; `ScatterChart([-16],[0])` marker at x≈1724.
- After: a symmetric clamp pulls `max_value` up to zero when the domain is all-negative. Mixed-sign and all-positive data are untouched.
- Pins flipped: `line_all_negative`, `bar_all_negative_gridline`, `scatter_all_negative_axis` (now in-frame regression tests).

## 2. Mixed-magnitude tick explosion

`calculate_axis_values` (and a duplicate loop in the `Axis.values` setter) chose the tick step from `common_denominators` of the endpoint magnitudes. For a domain like `(-1.0, 1e9)` the only common divisor is 1, so the grid-value list tried to materialise ~1e9 floats and raised `MemoryError`.

- After: a shared `_grid_step`/`_grid_values` helper caps the raw tick count and falls back to a `round_to_clean_number` nice-number step. Both loops use it. `AreaChart([-1.0, 1e9]).to_svg()` now renders in ~20ms inside the suite's 192 MiB cap instead of OOMing.
- Removing the suite's tick-explosion generation filter let the property tests reach mismatched-magnitude value axes, whose wide numeric tick labels could collide. Added a width-aware overlap pass to the axis labels that only drops colliding labels (endpoints kept), so fitting axes render byte-for-byte the same.
- Test changes: dropped the `_axis_tick_list_bounded` predictor/filter and the `MemoryError` catch, broadened the strategies/in-frame tests to the full adversarial range, and converted the inverted mixed-magnitude pin to a render regression test. Kept the 192 MiB rlimit fixture as cheap host insurance (it is no longer load-bearing).

## 3. Empty-label ZeroDivisionError

A dense ordinal axis rotates its labels and shifted each by `label.width / len(label.text)`. An empty label made `len('') == 0` and raised an uncaught `ZeroDivisionError`. Guarded the division (an empty label has zero width and nothing to shift). Affected ColumnChart and LineChart.

## 4. Small-canvas bottom-label overflow

`LayoutEngine.bottom_padding` was a flat fraction of the height. Bottom tick labels are drawn DEFAULT_PADDING below the plot, so on short canvases (height < ~360px) the band fell below DEFAULT_PADDING and the labels spilled past the viewBox (baseline at y=246 on a 240px chart). Now reserves at least DEFAULT_PADDING. The horizontal bar chart's value labels are not in `x_labels`, so the reservation is unconditional; canvases >= ~360px already exceed it, so every 500px baseline fixture is unchanged.

## 5. Rotated-axis label overlap (review follow-up)

The width-aware overlap pass from section 2 ran only when the axis was not rotated, so dense rotated tick labels still overlapped. `test_line_no_label_overlap` reproduced this with 26 cycled CJK labels on a 500x500 line chart: the last two rotated labels collided (boxes ending ~471 and ~488 against a forced final at ~493). This was pre-existing on the base branch.

The rotation angle is sized from label width alone and ignores label height, so a rotated label's projected footprint still spans more than its tick pitch and adjacent labels collide. `_non_overlapping_indices` now takes the rotation angle and, for rotated axes, measures each label by the x-extent of its rotated bounding box (one character pivot shift, baseline-anchored, projected onto the x axis), matching the absolute geometry the invariant tests recompute from the rendered SVG. The greedy first/last/minimal-middle logic is unchanged, so axes whose rotated labels already fit keep every label.

## 6. Direct unit tests for the overlap pass

`XAxis._non_overlapping_indices` previously had no targeted unit test, so a future bug could silently drop labels. Added `TestNonOverlappingIndices` (tests/charts/test_axes.py) pinning the kept set for: non-colliding inputs (all kept), tightly-packed colliding labels (first + last + minimal middles), dx-offset invariance, the rotated-path variant (fitting rotated labels all kept, colliding ones thinned), and the chain-collision case where the forced final label overlaps the last kept middle and only that blocker is dropped.

## Evidence / gates

- Invariant suite (`tests/test_geometric_invariants.py`): green on every hypothesis seed 1 through 13 explicitly, plus 4 random-seed runs. (The earlier "green across 6+ seeds" claim was wrong: the rotated-overlap failure above reproduced on seeds 3 and 13, and on the base branch on seeds 6/9/10/12/13. Those now pass.)
- New axis unit tests: `tests/charts/test_axes.py::TestNonOverlappingIndices`, 9 cases, all pass.
- Existing suite (`pytest -k "not png"`, excluding benchmarks): passes with 0 new failures; benchmarks pass separately. The four negative-value PNG baselines pass unchanged (the projection fix only touches all-negative data; those fixtures use mixed-sign data), so no baseline regeneration was needed.
- `ruff check charted/ tests/` clean; `mypy` (strict, no explicit Any, configured to check `charted/`) clean.
- Visual spot-checks rendered to PNG and eyeballed: all-negative line/bar/scatter, `AreaChart([-1.0, 1e9])`, small 320x240 bar/column, and a rotated 8-label column chart (520x420) whose surviving rotated labels are present, legible, and non-overlapping. Normal-size and mixed-sign charts unchanged.
