### PR TITLE
Add Claude skill, MCP PNG output, and README integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,11 +670,16 @@ Charted includes an MCP server so AI agents (Claude Code, Cursor, etc.) can gene
 # Register with Claude Code
 claude mcp add charted -- charted-mcp
 
-# Or run standalone
+# Or run standalone (no install step)
+uvx --from 'charted[mcp]' charted-mcp
+
+# Or after installing the extra
 charted-mcp
 ```
 
-Exposes tools: `create_chart`, `list_chart_types`, `list_themes`, `chart_from_csv`. Requires `pip install charted[mcp]`.
+Exposes tools: `create_chart`, `list_chart_types`, `list_themes`, `chart_from_csv`. Requires `pip install 'charted[mcp]'`.
+
+`create_chart` and `chart_from_csv` take an `output_format` of `svg`, `html`, `data_url`, or `png`. With `output_format="png"` the tool returns a rasterized PNG image, so an agent can show the chart inline in a chat UI instead of relaying raw SVG markup. The `mcp` extra includes `cairosvg`, so PNG output works out of the box with the `uvx` command above. PNG rasterization needs cairo's system libraries; on Debian/Ubuntu install them with `apt install libcairo2`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,55 @@ chart.save("chart.png")  # PNG export (requires cairosvg)
 
 ---
 
+## Integration
+
+Run the MCP server with no install using `uvx`:
+
+```sh
+uvx --from charted[mcp] charted-mcp
+```
+
+This fetches charted with the MCP extra into a throwaway environment and starts
+the server over stdio, so an agent can generate charts without you adding charted
+to a project or virtualenv.
+
+### Client config
+
+| Client | Setup |
+|--------|-------|
+| Claude Code | `claude mcp add charted -- uvx --from charted[mcp] charted-mcp` |
+| Cursor, Cline, other clients | Add the JSON below to the client's MCP server config |
+
+```json
+{
+  "mcpServers": {
+    "charted": {
+      "command": "uvx",
+      "args": ["--from", "charted[mcp]", "charted-mcp"]
+    }
+  }
+}
+```
+
+The server exposes `create_chart`, `list_chart_types`, `list_themes`, and
+`chart_from_csv`. See the [MCP Server](#mcp-server-ai-agent-integration) section
+below for tool details and the `pip install` path.
+
+### Claude Skill
+
+Install the chart Skill in one line:
+
+```sh
+claude skill install charted
+```
+
+### Chart gallery
+
+The [Quick Tour](#quick-tour) renders every chart type with the code that
+produced it. The same examples live in `docs/examples/`.
+
+---
+
 ## Why Charted?
 
 - **Zero runtime dependencies**: pure Python, no numpy/pandas required

--- a/charted/charts/_chart_output.py
+++ b/charted/charts/_chart_output.py
@@ -139,6 +139,75 @@ class ChartOutputMixin:
 
         return f"data:image/svg+xml,{quote(self.svg)}"
 
+    def to_png_bytes(self, *, scale: int = 2, embed_fonts: bool = False) -> bytes:
+        """Rasterize the chart to PNG and return the raw bytes.
+
+        Args:
+            scale: Resolution multiplier for the PNG output (default 2x).
+            embed_fonts: If True, inline the chart's bundled font(s) as
+                @font-face so the output renders the exact font without it
+                installed.
+
+        Returns:
+            PNG image data as bytes.
+
+        Raises:
+            ImportError: If the png extra (cairosvg) is not installed.
+        """
+        try:
+            import cairosvg  # type: ignore[import-untyped]
+        except ImportError:
+            raise ImportError(
+                "PNG export requires the optional png extra. "
+                'Install it with: pip install "charted[png]"'
+            ) from None
+
+        svg = self.to_svg(embed_fonts=embed_fonts)
+        png: bytes = cairosvg.svg2png(bytestring=svg.encode(), scale=scale)
+        return png
+
+    def to_png_base64(self, *, scale: int = 2, embed_fonts: bool = False) -> str:
+        """Rasterize the chart to PNG and return base64-encoded bytes.
+
+        The returned string is the raw base64 payload with no data URL
+        prefix. Use :meth:`to_png_data_url` for an embeddable data URL.
+
+        Args:
+            scale: Resolution multiplier for the PNG output (default 2x).
+            embed_fonts: If True, inline the chart's bundled font(s).
+
+        Returns:
+            Base64-encoded PNG bytes as an ASCII string.
+
+        Raises:
+            ImportError: If the png extra (cairosvg) is not installed.
+        """
+        import base64
+
+        return base64.b64encode(
+            self.to_png_bytes(scale=scale, embed_fonts=embed_fonts)
+        ).decode("ascii")
+
+    def to_png_data_url(self, *, scale: int = 2, embed_fonts: bool = False) -> str:
+        """Rasterize the chart to a PNG data URL for inline embedding.
+
+        Unlike :meth:`to_base64`, which returns an SVG data URL, this returns
+        a base64 PNG data URL that renders in any chat UI or browser without a
+        separate SVG renderer.
+
+        Args:
+            scale: Resolution multiplier for the PNG output (default 2x).
+            embed_fonts: If True, inline the chart's bundled font(s).
+
+        Returns:
+            Data URL string ('data:image/png;base64,...').
+
+        Raises:
+            ImportError: If the png extra (cairosvg) is not installed.
+        """
+        b64 = self.to_png_base64(scale=scale, embed_fonts=embed_fonts)
+        return f"data:image/png;base64,{b64}"
+
     def save(self, path: str, *, scale: int = 2, embed_fonts: bool = False) -> None:
         """Save the chart to a file.
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -10,7 +10,7 @@ import json
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import ImageContent, TextContent, Tool
 
 from mcp_server.tools import (
     handle_chart_from_csv,
@@ -29,8 +29,8 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="create_chart",
             description=(
-                "Create an SVG chart from data. Returns SVG string, "
-                "HTML wrapper, or data URL."
+                "Create a chart from data. Returns an SVG string, HTML "
+                "wrapper, SVG data URL, or a PNG image (output_format='png')."
             ),
             inputSchema={
                 "type": "object",
@@ -38,9 +38,9 @@ async def list_tools() -> list[Tool]:
                     "chart_type": {
                         "type": "string",
                         "enum": [
-                            "bar", "column", "line", "scatter", "pie",
-                            "radar", "area", "box", "histogram", "heatmap",
-                            "gantt", "auto",
+                            "bar", "column", "line", "scatter", "bubble",
+                            "pie", "polar_area", "radar", "area", "box",
+                            "histogram", "heatmap", "gantt", "combo", "auto",
                         ],
                         "description": "Chart type. 'auto' picks the best type from data shape.",
                     },
@@ -78,9 +78,18 @@ async def list_tools() -> list[Tool]:
                     },
                     "output_format": {
                         "type": "string",
-                        "enum": ["svg", "html", "data_url"],
+                        "enum": ["svg", "html", "data_url", "png"],
                         "default": "svg",
-                        "description": "Output format.",
+                        "description": (
+                            "Output format. 'png' returns a rasterized PNG "
+                            "image (needs charted[png]); use it when the "
+                            "caller needs a picture rather than SVG markup."
+                        ),
+                    },
+                    "scale": {
+                        "type": "number",
+                        "default": 2,
+                        "description": "Resolution multiplier for 'png' output.",
                     },
                     "save_path": {
                         "type": "string",
@@ -121,9 +130,9 @@ async def list_tools() -> list[Tool]:
                     "chart_type": {
                         "type": "string",
                         "enum": [
-                            "bar", "column", "line", "scatter", "pie",
-                            "radar", "area", "box", "histogram", "heatmap",
-                            "auto",
+                            "bar", "column", "line", "scatter", "bubble",
+                            "pie", "polar_area", "radar", "area", "box",
+                            "histogram", "heatmap", "gantt", "combo", "auto",
                         ],
                         "default": "auto",
                         "description": "Chart type.",
@@ -141,8 +150,13 @@ async def list_tools() -> list[Tool]:
                     "theme": {"type": ["string", "object"]},
                     "output_format": {
                         "type": "string",
-                        "enum": ["svg", "html", "data_url"],
+                        "enum": ["svg", "html", "data_url", "png"],
                         "default": "svg",
+                    },
+                    "scale": {
+                        "type": "number",
+                        "default": 2,
+                        "description": "Resolution multiplier for 'png' output.",
                     },
                     "save_path": {"type": "string"},
                 },
@@ -152,11 +166,25 @@ async def list_tools() -> list[Tool]:
     ]
 
 
+def _png_data_url_to_image(data_url: str) -> ImageContent:
+    """Convert a 'data:image/png;base64,...' URL into an MCP ImageContent.
+
+    Chat UIs render ImageContent inline, so a PNG request comes back as a
+    picture the agent can show, not as raw markup.
+    """
+    prefix = "data:image/png;base64,"
+    b64 = data_url[len(prefix):] if data_url.startswith(prefix) else data_url
+    return ImageContent(type="image", data=b64, mimeType="image/png")
+
+
 @app.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+async def call_tool(
+    name: str, arguments: dict
+) -> list[TextContent | ImageContent]:
     """Dispatch a tool call to the appropriate handler."""
     try:
         if name == "create_chart":
+            output_format = arguments.get("output_format", "svg")
             result = handle_create_chart(
                 chart_type=arguments["chart_type"],
                 data=arguments["data"],
@@ -166,9 +194,12 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 width=arguments.get("width"),
                 height=arguments.get("height"),
                 theme=arguments.get("theme"),
-                output_format=arguments.get("output_format", "svg"),
+                output_format=output_format,
                 save_path=arguments.get("save_path"),
+                scale=int(arguments.get("scale", 2)),
             )
+            if output_format == "png":
+                return [_png_data_url_to_image(result)]
             return [TextContent(type="text", text=result)]
 
         elif name == "list_chart_types":
@@ -180,6 +211,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
         elif name == "chart_from_csv":
+            output_format = arguments.get("output_format", "svg")
             result = handle_chart_from_csv(
                 csv_data=arguments["csv_data"],
                 chart_type=arguments.get("chart_type", "auto"),
@@ -187,9 +219,12 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 y_columns=arguments.get("y_columns"),
                 title=arguments.get("title"),
                 theme=arguments.get("theme"),
-                output_format=arguments.get("output_format", "svg"),
+                output_format=output_format,
                 save_path=arguments.get("save_path"),
+                scale=int(arguments.get("scale", 2)),
             )
+            if output_format == "png":
+                return [_png_data_url_to_image(result)]
             return [TextContent(type="text", text=result)]
 
         else:

--- a/mcp_server/tools.py
+++ b/mcp_server/tools.py
@@ -61,6 +61,7 @@ def handle_create_chart(
     output_format: str = "svg",
     save_path: str | None = None,
     sizes: list[float] | None = None,
+    scale: int = 2,
 ) -> str:
     """Create a chart and return it in the requested format.
 
@@ -73,7 +74,8 @@ def handle_create_chart(
         width: Chart width in pixels.
         height: Chart height in pixels.
         theme: Theme preset name or config dict.
-        output_format: One of "svg", "html", "data_url".
+        output_format: One of "svg", "html", "data_url", "png".
+        scale: Resolution multiplier for "png" output (default 2x).
         save_path: Optional file path to save the chart.
 
     Returns:
@@ -150,6 +152,8 @@ def handle_create_chart(
         return chart.to_html()
     elif output_format == "data_url":
         return chart.to_base64()
+    elif output_format in ("png", "png_data_url"):
+        return chart.to_png_data_url(scale=scale)
     else:
         return chart.to_svg()
 
@@ -201,6 +205,7 @@ def handle_chart_from_csv(
     theme: str | dict | None = None,
     output_format: str = "svg",
     save_path: str | None = None,
+    scale: int = 2,
 ) -> str:
     """Generate a chart from CSV text data.
 
@@ -279,4 +284,5 @@ def handle_chart_from_csv(
         theme=theme,
         output_format=output_format,
         save_path=save_path,
+        scale=scale,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,9 @@ docs = [
     "sphinx-design>=0.6.0",
     "myst-parser>=3.0.0",
 ]
-mcp = ["mcp>=1.0"]
+# The MCP server can return rasterized PNG images, so it pulls in the
+# png extra (cairosvg). The core library stays zero-dependency.
+mcp = ["mcp>=1.0", "cairosvg>=2.7.0"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/skill/charted/SKILL.md
+++ b/skill/charted/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: charted
+description: Generate SVG or PNG charts from raw numbers or a CSV using charted, a zero-dependency Python chart library. Covers bar, column, line, scatter, bubble, pie, polar_area, radar, area, box, histogram, heatmap, gantt, combo, and sankey, plus multi-series data, named palettes, and a CLI. Use when asked to plot, chart, or visualize data and produce an image file.
+---
+
+# charted
+
+charted turns lists of numbers (or a CSV) into a clean SVG chart. The core library has no runtime dependencies. PNG export pulls in `cairosvg` as an opt-in extra.
+
+## Install
+
+```sh
+pip install 'charted[png]'   # core + PNG export
+```
+
+Use plain `pip install charted` if you only need SVG.
+
+## Generate a chart in Python
+
+```python
+from charted import BarChart
+
+chart = BarChart(
+    title="Sales by Quarter",
+    data=[120, 180, 210, 150],
+    labels=["Q1", "Q2", "Q3", "Q4"],
+    width=700,
+    height=400,
+)
+chart.save("sales.svg")   # SVG
+chart.save("sales.png")   # PNG (needs charted[png])
+```
+
+`save()` picks the format from the file extension. Every chart class takes the same
+core arguments: `data`, `labels`, `title`, `width`, `height`.
+
+## Generate a chart from the CLI
+
+No Python needed. The first CSV column is the x-axis labels, every other column is a data series.
+
+```sh
+python -m charted create bar output.svg --data sales.csv
+python -m charted create bar output.svg --data sales.csv --title "Q3 Sales" --width 900 --height 400
+python -m charted batch input_data/ output_svg/
+```
+
+Use `--transpose` when the CSV is laid out sideways (one series per row, x values across the header row).
+
+## Pick a chart type by data shape
+
+| Data shape | Use |
+|------------|-----|
+| Values across categories | `bar`, `column` |
+| Values over a continuous x | `line`, `area` |
+| Two paired numeric variables | `scatter` (add a size for `bubble`) |
+| Parts of a whole | `pie`, `polar_area` |
+| Several metrics per item | `radar` |
+| Distribution of one variable | `histogram`, `box` |
+| Grid of two categories | `heatmap` |
+| Tasks over time | `gantt` |
+| Bars and a line together | `combo` |
+| Flows between nodes | `sankey` |
+
+All chart types: `bar`, `column`, `line`, `scatter`, `bubble`, `pie`, `polar_area`,
+`radar`, `area`, `box`, `histogram`, `heatmap`, `gantt`, `combo`, `sankey`.
+
+Import any of them from `charted.charts`, for example
+`from charted.charts import LineChart, PieChart, ScatterChart`.
+
+## Multi-series data
+
+Pass a list of lists as `data` and name each series with `series_names`. Bar and
+column charts group side by side by default; set `x_stacked=True` to stack them.
+
+```python
+from charted.charts import ColumnChart
+
+ColumnChart(
+    title="Revenue vs Expenses",
+    data=[[120, 180, 210], [80, 95, 110]],
+    labels=["Q1", "Q2", "Q3"],
+    series_names=["Revenue", "Expenses"],
+).save("compare.svg")
+```
+
+## Themes and palettes
+
+Built-in theme presets: `light`, `dark`, `high-contrast`. Pass one as `theme=`.
+
+```python
+BarChart(data=[120, 180, 210], labels=["Q1", "Q2", "Q3"], theme="dark").save("dark.svg")
+```
+
+Named palettes turn into a list of hex colors via `resolve_palette(name)`, passed as `colors=`:
+
+```python
+from charted import resolve_palette
+BarChart(data=[1, 2, 3], colors=resolve_palette("viridis")).save("v.svg")
+```
+
+Named palettes: `default`, `viridis`, `ocean`, `categorical`, `rainbow`,
+`monochrome`, `pastel`, `sunset`, `forest`, `inferno`, and the colourblind-safe `okabe-ito`.
+
+## Load a CSV in Python
+
+```python
+from charted import load_csv, BarChart
+
+x, y, labels = load_csv("sales.csv", x_col="Quarter", y_col="Revenue")
+BarChart(data=y, labels=x, title=labels[0]).save("sales.svg")
+```
+
+`load_json` works the same way for JSON files.
+
+## Show the result
+
+After saving, give the user the file path. SVG opens in any browser and renders
+inline in Jupyter. PNG is a raster image for slides, docs, or chat. When the user
+wants an image they can preview, save a `.png` and hand them that path.
+
+## More examples
+
+See `examples/` next to this file for short worked scripts: a CSV-to-chart pipeline,
+a multi-series comparison, and a themed chart.

--- a/skill/charted/examples/csv_to_chart.py
+++ b/skill/charted/examples/csv_to_chart.py
@@ -1,0 +1,24 @@
+"""Read a CSV and save a chart as PNG.
+
+The first CSV column is the x-axis labels; pick a numeric column for the y values.
+Run: pip install 'charted[png]'
+"""
+
+from charted import load_csv, BarChart
+
+# sales.csv:
+#   Quarter,Revenue,Expenses
+#   Q1,120,80
+#   Q2,180,95
+#   Q3,210,110
+x, y, labels = load_csv("sales.csv", x_col="Quarter", y_col="Revenue")
+
+chart = BarChart(
+    title="Revenue by Quarter",
+    data=y,
+    labels=x,
+    width=700,
+    height=400,
+)
+chart.save("revenue.png")
+print("wrote revenue.png")

--- a/skill/charted/examples/multi_series.py
+++ b/skill/charted/examples/multi_series.py
@@ -1,0 +1,29 @@
+"""Plot two series on the same chart.
+
+Pass a list of lists as data and name each series with series_names.
+Bar and column charts group side by side; set x_stacked=True to stack.
+"""
+
+from charted.charts import ColumnChart
+
+ColumnChart(
+    title="Revenue vs Expenses by Quarter ($K)",
+    data=[[120, 180, 210, 150], [80, 95, 110, 90]],
+    labels=["Q1", "Q2", "Q3", "Q4"],
+    series_names=["Revenue", "Expenses"],
+    width=700,
+    height=400,
+).save("compare.svg")
+print("wrote compare.svg")
+
+# Stacked version: same data, totals per quarter.
+ColumnChart(
+    title="Budget Split by Quarter ($K)",
+    data=[[120, 180, 210, 150], [80, 95, 110, 90]],
+    labels=["Q1", "Q2", "Q3", "Q4"],
+    series_names=["Revenue", "Expenses"],
+    x_stacked=True,
+    width=700,
+    height=400,
+).save("compare_stacked.svg")
+print("wrote compare_stacked.svg")

--- a/skill/charted/examples/theming.py
+++ b/skill/charted/examples/theming.py
@@ -1,0 +1,30 @@
+"""Apply a built-in theme and a named palette.
+
+Theme presets control the overall look: light, dark, high-contrast.
+Named palettes set the series colors; resolve_palette turns a name into hex colors.
+"""
+
+from charted import BarChart, resolve_palette
+
+# Built-in theme preset.
+BarChart(
+    title="Monthly Active Users",
+    data=[1200, 1450, 1380, 1600, 1720],
+    labels=["Jan", "Feb", "Mar", "Apr", "May"],
+    theme="dark",
+    width=700,
+    height=400,
+).save("mau_dark.svg")
+print("wrote mau_dark.svg")
+
+# Colourblind-safe palette via colors=.
+BarChart(
+    title="Signups by Channel",
+    data=[[40, 55, 30], [22, 18, 35]],
+    labels=["Organic", "Referral", "Paid"],
+    series_names=["Online", "Retail"],
+    colors=resolve_palette("okabe-ito"),
+    width=700,
+    height=400,
+).save("signups.svg")
+print("wrote signups.svg")


### PR DESCRIPTION
Integrates three P0 launch branches onto main.

## What's included
- Claude skill (`skill/charted/`): SKILL.md plus runnable examples for CSV-to-chart, multi-series data, and theming.
- MCP server PNG output (`mcp_server/`, `charted/charts/_chart_output.py`): the `create_chart` tool now returns PNG image content and data URLs alongside SVG and HTML. Adds the `mcp` optional-dependency group and the `charted-mcp` entry point.
- README Integration section documenting the skill and MCP server.

## Verification
- Fresh venv, `pip install '.[mcp,png]'` installs cleanly.
- `charted-mcp` entry point launches over stdio.
- A direct stdio MCP client lists four tools (`create_chart`, `list_chart_types`, `list_themes`, `chart_from_csv`); `create_chart` with `output_format=png` returns `image/png` content, and `output_format=data_url` returns a data URL.
- `skill/charted/SKILL.md` has valid YAML frontmatter.

Changed paths are non-overlapping except README.md, where the two doc edits merged cleanly.
