### PR TITLE
Add glama.json and enrich MCP tool descriptions

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "marzukia"
+  ]
+}

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -29,8 +29,12 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="create_chart",
             description=(
-                "Create a chart from data. Returns an SVG string, HTML "
-                "wrapper, SVG data URL, or a PNG image (output_format='png')."
+                "Generate an SVG, HTML, data-URL, or rasterized PNG chart from "
+                "structured data. Supports 14 chart types (bar, column, line, "
+                "scatter, bubble, pie, polar_area, radar, area, box, histogram, "
+                "heatmap, gantt, combo) plus 'auto' which picks the best type "
+                "automatically. Use this when you have data already in memory as "
+                "a list or dict; for CSV input prefer chart_from_csv instead."
             ),
             inputSchema={
                 "type": "object",
@@ -42,58 +46,110 @@ async def list_tools() -> list[Tool]:
                             "pie", "polar_area", "radar", "area", "box",
                             "histogram", "heatmap", "gantt", "combo", "auto",
                         ],
-                        "description": "Chart type. 'auto' picks the best type from data shape.",
+                        "description": (
+                            "The type of chart to render. 'auto' inspects the "
+                            "data shape and picks the most appropriate type. "
+                            "Examples: 'bar' for horizontal category comparison, "
+                            "'line' for time-series trends, 'pie' for "
+                            "part-of-whole proportions, 'scatter' for XY "
+                            "correlation, 'heatmap' for a 2-D color matrix."
+                        ),
                     },
                     "data": {
                         "type": ["array", "object"],
-                        "description": "Chart data. 1D array for single series, 2D for multi-series.",
+                        "description": (
+                            "Chart data. For a single series pass a 1-D list of "
+                            "numbers, e.g. [10, 20, 15]. For multiple series pass "
+                            "a 2-D list where each inner list is one series, e.g. "
+                            "[[10, 20], [5, 30]]. Scatter/bubble charts expect "
+                            "[[x_values], [y_values]]."
+                        ),
                     },
                     "labels": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "X-axis category labels.",
+                        "description": (
+                            "Category labels for the x-axis, one per data point. "
+                            "Example: ['Jan', 'Feb', 'Mar']. Omit for numeric or "
+                            "auto-indexed axes."
+                        ),
                     },
                     "title": {
                         "type": "string",
-                        "description": "Chart title.",
+                        "description": (
+                            "Optional chart title rendered above the plot area. "
+                            "Example: 'Monthly Revenue 2024'."
+                        ),
                     },
                     "series_names": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Names for each data series (used in legend).",
+                        "description": (
+                            "Display names for each data series, shown in the "
+                            "chart legend. Must match the number of series in "
+                            "data. Example: ['Revenue', 'Costs']."
+                        ),
                     },
                     "width": {
                         "type": "number",
                         "default": 500,
-                        "description": "Chart width in pixels.",
+                        "description": (
+                            "Chart canvas width in pixels. Default is 500. "
+                            "Increase for more detail or wider labels."
+                        ),
                     },
                     "height": {
                         "type": "number",
                         "default": 500,
-                        "description": "Chart height in pixels.",
+                        "description": (
+                            "Chart canvas height in pixels. Default is 500. "
+                            "Adjust to control aspect ratio."
+                        ),
                     },
                     "theme": {
                         "type": ["string", "object"],
-                        "description": "Theme preset name or config object.",
+                        "description": (
+                            "Visual theme. Pass a preset name ('light', 'dark', "
+                            "'high-contrast') or a palette name ('viridis', "
+                            "'plasma', 'ocean', etc.) as a string, or a config "
+                            "object such as {'colors': 'viridis', "
+                            "'background_color': '#1a1a2e'}. Use "
+                            "list_themes to see all available options."
+                        ),
                     },
                     "output_format": {
                         "type": "string",
                         "enum": ["svg", "html", "data_url", "png"],
                         "default": "svg",
                         "description": (
-                            "Output format. 'png' returns a rasterized PNG "
-                            "image (needs charted[png]); use it when the "
-                            "caller needs a picture rather than SVG markup."
+                            "Format for the returned chart. 'svg' returns raw "
+                            "SVG markup (default, zero extra dependencies). "
+                            "'html' wraps the SVG in a minimal HTML page. "
+                            "'data_url' returns a base64 SVG data URL suitable "
+                            "for use in an img src attribute. 'png' rasterizes "
+                            "the chart to a PNG image (requires charted[png]) and "
+                            "returns it as inline image content visible in chat UIs."
                         ),
                     },
                     "scale": {
                         "type": "number",
                         "default": 2,
-                        "description": "Resolution multiplier for 'png' output.",
+                        "description": (
+                            "Resolution multiplier applied when output_format is "
+                            "'png'. A value of 2 (default) doubles the pixel "
+                            "dimensions for high-DPI displays. Has no effect for "
+                            "SVG output."
+                        ),
                     },
                     "save_path": {
                         "type": "string",
-                        "description": "Optional file path to save the chart.",
+                        "description": (
+                            "Optional absolute or relative file path where the "
+                            "chart should also be saved on disk. The file "
+                            "extension should match output_format (e.g. "
+                            "'chart.svg' or 'chart.png'). The tool still "
+                            "returns the chart content regardless."
+                        ),
                     },
                 },
                 "required": ["chart_type", "data"],
@@ -101,7 +157,12 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_chart_types",
-            description="List all supported chart types with descriptions.",
+            description=(
+                "Return the full list of chart types supported by charted, "
+                "each with its type identifier and a short description of what "
+                "it is best suited for. Call this before create_chart or "
+                "chart_from_csv when you are unsure which chart_type to choose."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -110,7 +171,12 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_themes",
-            description="List available theme presets and color palettes.",
+            description=(
+                "Return all available theme presets and named color palettes "
+                "that can be passed to the theme parameter of create_chart or "
+                "chart_from_csv. Also returns a usage hint showing how to "
+                "combine a palette with custom background and foreground colors."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -119,13 +185,25 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="chart_from_csv",
-            description="Generate a chart directly from CSV text data.",
+            description=(
+                "Parse raw CSV text and generate a chart directly from it, "
+                "without requiring the caller to pre-process the data. The tool "
+                "auto-detects numeric columns for the y-axis and uses the first "
+                "non-numeric column as x-axis labels. Use this when the user "
+                "provides CSV content directly; for data already in a Python "
+                "list or dict use create_chart instead."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "csv_data": {
                         "type": "string",
-                        "description": "Raw CSV text (with header row).",
+                        "description": (
+                            "Complete CSV text including a header row. Columns "
+                            "are auto-classified as labels (non-numeric) or data "
+                            "series (numeric). Newlines should be literal line "
+                            "breaks. Example header row: Month,Sales."
+                        ),
                     },
                     "chart_type": {
                         "type": "string",
@@ -135,30 +213,72 @@ async def list_tools() -> list[Tool]:
                             "histogram", "heatmap", "gantt", "combo", "auto",
                         ],
                         "default": "auto",
-                        "description": "Chart type.",
+                        "description": (
+                            "The type of chart to render. Defaults to 'auto', "
+                            "which picks the best type based on the data shape. "
+                            "See list_chart_types for descriptions of each option."
+                        ),
                     },
                     "x_column": {
                         "type": "string",
-                        "description": "Column name for x-axis labels.",
+                        "description": (
+                            "Name of the CSV column to use as x-axis category "
+                            "labels. If omitted, the first non-numeric column is "
+                            "used automatically. Example: 'Month'."
+                        ),
                     },
                     "y_columns": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Column names for y-axis data series.",
+                        "description": (
+                            "Names of CSV columns to plot as data series. If "
+                            "omitted, all numeric columns (except x_column) are "
+                            "used. Example: ['Revenue', 'Costs']."
+                        ),
                     },
-                    "title": {"type": "string"},
-                    "theme": {"type": ["string", "object"]},
+                    "title": {
+                        "type": "string",
+                        "description": (
+                            "Optional chart title rendered above the plot area. "
+                            "Example: 'Q1 Sales by Region'."
+                        ),
+                    },
+                    "theme": {
+                        "type": ["string", "object"],
+                        "description": (
+                            "Visual theme. Pass a preset name ('light', 'dark', "
+                            "'high-contrast') or a palette name ('viridis', "
+                            "'plasma', etc.) as a string, or a config object. "
+                            "Use list_themes to see all options."
+                        ),
+                    },
                     "output_format": {
                         "type": "string",
                         "enum": ["svg", "html", "data_url", "png"],
                         "default": "svg",
+                        "description": (
+                            "Format for the returned chart: 'svg' (default), "
+                            "'html', 'data_url' (base64 SVG), or 'png' "
+                            "(rasterized image, requires charted[png])."
+                        ),
                     },
                     "scale": {
                         "type": "number",
                         "default": 2,
-                        "description": "Resolution multiplier for 'png' output.",
+                        "description": (
+                            "Resolution multiplier for 'png' output. Default 2 "
+                            "gives high-DPI output. Has no effect for SVG formats."
+                        ),
                     },
-                    "save_path": {"type": "string"},
+                    "save_path": {
+                        "type": "string",
+                        "description": (
+                            "Optional file path to also save the chart on disk. "
+                            "Extension should match output_format, e.g. "
+                            "'output/chart.svg'. The tool still returns the "
+                            "chart content in the response."
+                        ),
+                    },
                 },
                 "required": ["csv_data"],
             },

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -111,7 +111,7 @@ async def list_tools() -> list[Tool]:
                         "description": (
                             "Visual theme. Pass a preset name ('light', 'dark', "
                             "'high-contrast') or a palette name ('viridis', "
-                            "'plasma', 'ocean', etc.) as a string, or a config "
+                            "'inferno', 'ocean', etc.) as a string, or a config "
                             "object such as {'colors': 'viridis', "
                             "'background_color': '#1a1a2e'}. Use "
                             "list_themes to see all available options."
@@ -125,7 +125,7 @@ async def list_tools() -> list[Tool]:
                             "Format for the returned chart. 'svg' returns raw "
                             "SVG markup (default, zero extra dependencies). "
                             "'html' wraps the SVG in a minimal HTML page. "
-                            "'data_url' returns a base64 SVG data URL suitable "
+                            "'data_url' returns an SVG data URL suitable "
                             "for use in an img src attribute. 'png' rasterizes "
                             "the chart to a PNG image (requires charted[png]) and "
                             "returns it as inline image content visible in chat UIs."
@@ -248,7 +248,7 @@ async def list_tools() -> list[Tool]:
                         "description": (
                             "Visual theme. Pass a preset name ('light', 'dark', "
                             "'high-contrast') or a palette name ('viridis', "
-                            "'plasma', etc.) as a string, or a config object. "
+                            "'inferno', etc.) as a string, or a config object. "
                             "Use list_themes to see all options."
                         ),
                     },
@@ -258,7 +258,7 @@ async def list_tools() -> list[Tool]:
                         "default": "svg",
                         "description": (
                             "Format for the returned chart: 'svg' (default), "
-                            "'html', 'data_url' (base64 SVG), or 'png' "
+                            "'html', 'data_url' (SVG data URL), or 'png' "
                             "(rasterized image, requires charted[png])."
                         ),
                     },


### PR DESCRIPTION
## Summary

Adds two improvements to raise the Glama MCP registry quality score:

1. **glama.json** - Adds the missing registry metadata file at the repo root with the required schema reference and maintainer field.

2. **MCP tool descriptions** - Enriches all 4 tool definitions in `mcp_server/server.py` to provide clear, specific multi-sentence descriptions and complete parameter documentation:
   - `create_chart`: 3-sentence description explaining all supported chart types, output formats, and when to use it vs chart_from_csv. All 10 parameters now have detailed descriptions with examples and enum context.
   - `list_chart_types`: Clarified when to call this tool (before choosing a chart type).
   - `list_themes`: Clarified what the tool returns and how to use the palette hint.
   - `chart_from_csv`: 3-sentence description of auto-detection behavior and when to prefer it. Added missing descriptions for `title`, `theme`, and `save_path` parameters.

## Files changed

- `glama.json` (new) - Glama registry metadata
- `mcp_server/server.py` - Enriched tool and parameter descriptions in the list_tools() handler

## Tests

No behavior change. All existing tests pass.

## Verification

Pre-change: 1402 passed, 2 skipped, 18 errors (benchmark infra, pre-existing)
Post-change: 1402 passed, 2 skipped, 18 errors (identical - zero regressions)
ruff: all checks passed
mypy: no issues found in 74 source files

## Scope notes

Tool descriptions live in the `list_tools()` function in `server.py` (the MCP SDK surfaces these via the tools/list response, not docstrings). No runtime behavior changed - this is purely schema/documentation enrichment.

## Backend or frontend?

Backend.