### PR TITLE
fix: ruff lint on landing chart-gen script (unused import + import sort)

### DIFF
--- a/docs/_scripts/generate_landing_charts.py
+++ b/docs/_scripts/generate_landing_charts.py
@@ -3,45 +3,79 @@ Generate all landing page charts for charted's redesigned index.
 Outputs SVGs to docs/_static/landing/.
 Run from repo root: python docs/_scripts/generate_landing_charts.py
 """
-import math
+
+import os
 import random
 import sys
-import os
 
 sys.path.insert(0, os.path.abspath("."))
 
 from charted.charts import (
-    ColumnChart, BarChart, LineChart, ScatterChart, PieChart,
-    RadarChart, AreaChart, BubbleChart, ComboChart, HeatmapChart,
-    GanttChart, Histogram, PolarAreaChart, BoxPlot, SankeyChart,
+    AreaChart,
+    BarChart,
+    BoxPlot,
+    BubbleChart,
+    ColumnChart,
+    ComboChart,
+    GanttChart,
+    HeatmapChart,
+    Histogram,
+    LineChart,
+    PieChart,
+    PolarAreaChart,
+    RadarChart,
+    SankeyChart,
+    ScatterChart,
 )
 
 OUT = "docs/_static/landing"
 os.makedirs(OUT, exist_ok=True)
 
 # ─── LIGHT THEME (hero + code demos) ────────────────────────────────────────
-BRAND_COLORS = ["#5fab9e", "#db504a", "#f7dd72", "#f58b51", "#2e4756", "#7ec8bc", "#e87a74", "#f9e99a"]
+BRAND_COLORS = [
+    "#5fab9e",
+    "#db504a",
+    "#f7dd72",
+    "#f58b51",
+    "#2e4756",
+    "#7ec8bc",
+    "#e87a74",
+    "#f9e99a",
+]
 
 BASE_THEME = {
     "colors": BRAND_COLORS,
     "background_color": "#ffffff",
     "grid_color": "#e8edf0",
-    "title_color": "#2e4756", "root_color": "#2e4756", "legend_font_color": "#2e4756",
+    "title_color": "#2e4756",
+    "root_color": "#2e4756",
+    "legend_font_color": "#2e4756",
     "title_font_size": 15,
     "axis_label_font_size": 11,
 }
+
 
 def t(**overrides):
     d = dict(BASE_THEME)
     d.update(overrides)
     return d
 
+
 # ─── DARK THEME (gallery band only) ─────────────────────────────────────────
 # bg matches the band exactly (#0f1a20) so charts sit flush with no seam.
 # Gridlines: white at ~8% opacity — subtle structure without noise.
 # Text/axes: #c9d4d9 — readable but not harsh on dark.
 # Series: desaturated-vivid brand palette that reads well on dark.
-DARK_SERIES_COLORS = ["#5fab9e", "#db504a", "#f7dd72", "#f58b51", "#7ec8bc", "#e87a74", "#a8d5cd", "#f9e99a"]
+DARK_SERIES_COLORS = [
+    "#5fab9e",
+    "#db504a",
+    "#f7dd72",
+    "#f58b51",
+    "#7ec8bc",
+    "#e87a74",
+    "#a8d5cd",
+    "#f9e99a",
+]
 
 DARK_THEME = {
     "colors": DARK_SERIES_COLORS,
@@ -54,33 +88,49 @@ DARK_THEME = {
     "axis_label_font_size": 11,
 }
 
+
 def dt(**overrides):
     d = dict(DARK_THEME)
     d.update(overrides)
     return d
 
+
 # ─── HERO: Stacked AreaChart — monthly active users by plan ─────────────────
 # stacked=True (default) + high fill_opacity so each band reads as a clean
 # opaque-enough layer. Series ordered largest→smallest so the cumulative
 # stack makes visual sense (Free is the base, Enterprise the thin cap).
-months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-free_mau    = [1200, 1380, 1520, 1740, 1900, 2100, 2280, 2450, 2600, 2830, 3050, 3400]
-pro_mau     = [340,  420,  500,  610,  720,  860,  980, 1090, 1240, 1380, 1520, 1710]
-ent_mau     = [45,   62,   78,   95,  115,  138,  162,  189,  218,  250,  285,  325]
+months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
+free_mau = [1200, 1380, 1520, 1740, 1900, 2100, 2280, 2450, 2600, 2830, 3050, 3400]
+pro_mau = [340, 420, 500, 610, 720, 860, 980, 1090, 1240, 1380, 1520, 1710]
+ent_mau = [45, 62, 78, 95, 115, 138, 162, 189, 218, 250, 285, 325]
 
 # Pre-stack the data and draw back-to-front at full opacity so each band
 # paints cleanly over the one below: yellow cap (Enterprise total), red
 # mid-band (Free+Pro), teal base (Free). stacked=False so charted treats
 # each series independently against the x-axis baseline.
-total_mau = [f+p+e for f,p,e in zip(free_mau, pro_mau, ent_mau)]
-fp_mau    = [f+p    for f,p   in zip(free_mau, pro_mau)]
+total_mau = [f + p + e for f, p, e in zip(free_mau, pro_mau, ent_mau)]
+fp_mau = [f + p for f, p in zip(free_mau, pro_mau)]
 
 chart = AreaChart(
     title="Monthly Active Users by Plan",
     data=[total_mau, fp_mau, free_mau],
     labels=months,
     series_names=["Enterprise", "Pro", "Free"],
-    width=820, height=420,
+    width=820,
+    height=420,
     stacked=False,
     fill_opacity=1.0,
     theme=t(colors=["#f7dd72", "#db504a", "#5fab9e"], h_padding=0.12),
@@ -93,7 +143,8 @@ chart = BarChart(
     title="Revenue by Region ()",
     data=[4.2, 7.8, 6.1, 9.3, 5.5, 8.7],
     labels=["APAC", "North Am", "Europe", "LatAm", "MEA", "ANZ"],
-    width=560, height=340,
+    width=560,
+    height=340,
     theme=t(),
 )
 chart.save(f"{OUT}/demo_bar.svg")
@@ -101,16 +152,17 @@ print("demo_bar.svg ok")
 
 # ─── CODE DEMO 2: LineChart (multi-series) ───────────────────────────────────
 n = 12
-api_p50  = [42, 45, 41, 48, 52, 49, 44, 47, 53, 50, 46, 43]
-api_p95  = [88, 94, 87, 102, 118, 107, 91, 98, 122, 115, 95, 89]
-api_p99  = [165, 182, 155, 198, 247, 223, 171, 188, 261, 234, 192, 168]
+api_p50 = [42, 45, 41, 48, 52, 49, 44, 47, 53, 50, 46, 43]
+api_p95 = [88, 94, 87, 102, 118, 107, 91, 98, 122, 115, 95, 89]
+api_p99 = [165, 182, 155, 198, 247, 223, 171, 188, 261, 234, 192, 168]
 
 chart = LineChart(
     title="API Latency Percentiles (ms)",
     data=[api_p50, api_p95, api_p99],
     labels=months,
     series_names=["p50", "p95", "p99"],
-    width=560, height=340,
+    width=560,
+    height=340,
     theme=t(),
 )
 chart.save(f"{OUT}/demo_line.svg")
@@ -120,11 +172,21 @@ print("demo_line.svg ok")
 chart = ComboChart(
     title="Revenue vs Net Margin",
     series=[
-        {"data": [2.1, 2.8, 3.4, 2.9, 3.8, 4.2, 3.9, 4.7], "type": "column", "name": "Revenue ()"},
-        {"data": [8.2, 11.4, 13.8, 10.2, 15.1, 17.3, 14.9, 19.2], "type": "line", "name": "Margin %", "axis": "secondary"},
+        {
+            "data": [2.1, 2.8, 3.4, 2.9, 3.8, 4.2, 3.9, 4.7],
+            "type": "column",
+            "name": "Revenue ()",
+        },
+        {
+            "data": [8.2, 11.4, 13.8, 10.2, 15.1, 17.3, 14.9, 19.2],
+            "type": "line",
+            "name": "Margin %",
+            "axis": "secondary",
+        },
     ],
     labels=["Q1", "Q2", "Q3", "Q4", "Q5", "Q6", "Q7", "Q8"],
-    width=560, height=340,
+    width=560,
+    height=340,
     theme=t(),
 )
 chart.save(f"{OUT}/demo_combo.svg")
@@ -140,7 +202,8 @@ chart = ColumnChart(
     ],
     labels=["Q1", "Q2", "Q3", "Q4"],
     series_names=["Enterprise", "Mid-Market", "SMB"],
-    width=560, height=360,
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_column.svg")
@@ -150,8 +213,20 @@ print("gallery_column.svg ok")
 chart = BarChart(
     title="P95 Latency by Service (ms)",
     data=[12, 38, 24, 67, 19, 88, 31, 45, 15, 72],
-    labels=["auth", "search", "recommend", "media", "notify", "ml-infer", "checkout", "payment", "cdn", "analytics"],
-    width=560, height=360,
+    labels=[
+        "auth",
+        "search",
+        "recommend",
+        "media",
+        "notify",
+        "ml-infer",
+        "checkout",
+        "payment",
+        "cdn",
+        "analytics",
+    ],
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_bar.svg")
@@ -159,7 +234,7 @@ print("gallery_bar.svg ok")
 
 # ─── GALLERY 3: LineChart — stock index performance ──────────────────────────
 random.seed(7)
-weeks = [f"W{i+1}" for i in range(24)]
+weeks = [f"W{i + 1}" for i in range(24)]
 idx_a = [100]
 idx_b = [100]
 idx_c = [100]
@@ -173,7 +248,8 @@ chart = LineChart(
     data=[idx_a, idx_b, idx_c],
     labels=weeks,
     series_names=["Growth", "Blend", "Aggressive"],
-    width=560, height=360,
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_line.svg")
@@ -191,7 +267,8 @@ chart = ScatterChart(
     x_data=[effort_a, effort_b],
     y_data=[impact_a, impact_b],
     series_names=["Quick wins", "Large projects"],
-    width=560, height=360,
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_scatter.svg")
@@ -202,7 +279,8 @@ chart = PieChart(
     title="Cloud Spend by Provider",
     data=[44, 31, 14, 8, 3],
     labels=["AWS", "GCP", "Azure", "Self-hosted", "Other"],
-    width=520, height=380,
+    width=520,
+    height=380,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_pie.svg")
@@ -217,7 +295,8 @@ chart = RadarChart(
     ],
     labels=["Delivery", "Quality", "Security", "Perf", "UX", "Collab"],
     series_names=["Frontend", "Backend"],
-    width=520, height=380,
+    width=520,
+    height=380,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_radar.svg")
@@ -233,7 +312,8 @@ chart = AreaChart(
     ],
     labels=months,
     series_names=["Organic", "Paid", "Referral"],
-    width=560, height=360,
+    width=560,
+    height=360,
     stacked=True,
     fill_opacity=0.82,
     theme=dt(),
@@ -248,7 +328,8 @@ chart = BubbleChart(
     y_data=[18, 32, 8, 45, 12, 28, 22, 38],
     sizes=[120, 280, 450, 90, 680, 210, 380, 150],
     series_names=["Segments"],
-    width=560, height=360,
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_bubble.svg")
@@ -258,11 +339,30 @@ print("gallery_bubble.svg ok")
 chart = ComboChart(
     title="Quarterly Revenue & Gross Margin",
     series=[
-        {"data": [8.2, 9.7, 11.4, 10.8, 12.9, 14.2, 13.1, 15.8], "type": "column", "name": "Revenue ()"},
-        {"data": [38.2, 41.5, 44.1, 42.8, 46.3, 48.9, 45.7, 51.2], "type": "line", "name": "Gross Margin %", "axis": "secondary"},
+        {
+            "data": [8.2, 9.7, 11.4, 10.8, 12.9, 14.2, 13.1, 15.8],
+            "type": "column",
+            "name": "Revenue ()",
+        },
+        {
+            "data": [38.2, 41.5, 44.1, 42.8, 46.3, 48.9, 45.7, 51.2],
+            "type": "line",
+            "name": "Gross Margin %",
+            "axis": "secondary",
+        },
     ],
-    labels=["Q1 '23", "Q2 '23", "Q3 '23", "Q4 '23", "Q1 '24", "Q2 '24", "Q3 '24", "Q4 '24"],
-    width=560, height=360,
+    labels=[
+        "Q1 '23",
+        "Q2 '23",
+        "Q3 '23",
+        "Q4 '23",
+        "Q1 '24",
+        "Q2 '24",
+        "Q3 '24",
+        "Q4 '24",
+    ],
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_combo.svg")
@@ -288,7 +388,8 @@ chart = HeatmapChart(
     data=heatmap_data,
     x_labels=hours,
     y_labels=days,
-    width=580, height=360,
+    width=580,
+    height=360,
     low_color="#1a3040",
     high_color="#5fab9e",
     show_values=True,
@@ -303,7 +404,8 @@ chart = GanttChart(
     title="Product Launch Timeline: Q3–Q4 2026",
     data=[(0, 3), (1, 5), (2, 7), (4, 9), (6, 10), (8, 11), (9, 12)],
     labels=["Discovery", "Design", "Engineering", "Alpha", "Beta", "QA", "Launch"],
-    width=580, height=360,
+    width=580,
+    height=360,
     dependencies=[(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)],
     show_today_line=True,
     x_position=7.5,
@@ -326,7 +428,8 @@ chart = Histogram(
     title="HTTP Response Time Distribution (ms)",
     data=response_times,
     bins=16,
-    width=560, height=360,
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_histogram.svg")
@@ -337,7 +440,8 @@ chart = PolarAreaChart(
     title="NPS Score Distribution",
     data=[42, 28, 18, 32, 55, 61, 49, 38, 72, 84, 91],
     labels=["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
-    width=520, height=380,
+    width=520,
+    height=380,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_polar.svg")
@@ -345,15 +449,16 @@ print("gallery_polar.svg ok")
 
 # ─── GALLERY 14: BoxPlot — deployment duration by environment ────────────────
 random.seed(55)
-prod_times   = sorted([round(abs(random.gauss(8.5, 2.1)), 1) for _ in range(60)])
+prod_times = sorted([round(abs(random.gauss(8.5, 2.1)), 1) for _ in range(60)])
 staging_times = sorted([round(abs(random.gauss(4.2, 1.4)), 1) for _ in range(60)])
-dev_times    = sorted([round(abs(random.gauss(2.1, 0.8)), 1) for _ in range(60)])
+dev_times = sorted([round(abs(random.gauss(2.1, 0.8)), 1) for _ in range(60)])
 
 chart = BoxPlot(
     title="Deployment Duration by Environment (min)",
     data=[prod_times, staging_times, dev_times],
     labels=["Production", "Staging", "Development"],
-    width=560, height=360,
+    width=560,
+    height=360,
     theme=dt(),
 )
 chart.save(f"{OUT}/gallery_boxplot.svg")
@@ -361,19 +466,25 @@ print("gallery_boxplot.svg ok")
 
 # ─── GALLERY 15: SankeyChart — website conversion funnel ──────────────────────────────────
 sankey_nodes = [
-    "Website", "Organic Search", "Paid Ads", "Referral",
-    "Signup", "Trial", "Paid Plan", "Churned",
+    "Website",
+    "Organic Search",
+    "Paid Ads",
+    "Referral",
+    "Signup",
+    "Trial",
+    "Paid Plan",
+    "Churned",
 ]
 sankey_links = [
-    ("Website",        "Organic Search", 4500),
-    ("Website",        "Paid Ads",       2200),
-    ("Website",        "Referral",       1300),
-    ("Organic Search", "Signup",         1800),
-    ("Paid Ads",       "Signup",         1100),
-    ("Referral",       "Signup",          650),
-    ("Signup",         "Trial",          2800),
-    ("Trial",          "Paid Plan",       980),
-    ("Trial",          "Churned",        1820),
+    ("Website", "Organic Search", 4500),
+    ("Website", "Paid Ads", 2200),
+    ("Website", "Referral", 1300),
+    ("Organic Search", "Signup", 1800),
+    ("Paid Ads", "Signup", 1100),
+    ("Referral", "Signup", 650),
+    ("Signup", "Trial", 2800),
+    ("Trial", "Paid Plan", 980),
+    ("Trial", "Churned", 1820),
 ]
 chart = SankeyChart(
     nodes=sankey_nodes,


### PR DESCRIPTION
## Summary

Fixes two ruff errors in `docs/_scripts/generate_landing_charts.py` that were breaking CI on main after PR #92 merged:

- **F401**: removed unused `import math` (confirmed no `math.` calls in the file body)
- **I001**: sorted the import block per ruff/isort rules (`os`, `random`, `sys` alphabetically; moved `sys.path.insert` call after stdlib imports before the charted import)

`ruff format` also reflowed several long constructor-call lines to 88-char limit — no logic changes, purely whitespace.

## Verification

- `ruff check docs/_scripts/generate_landing_charts.py` → 0 errors
- `ruff check .` (whole repo) → 0 errors
- `python3 -c "import ast; ast.parse(open(...).read())"` → AST parse OK
- Confirmed `math` has no usages in the file before removal

Closes the CI failure introduced with the landing-page chart script.

## Scope notes

No behaviour change. The script generates SVG files; the only changes are import ordering and line reformatting. ruff format touching the whole file is expected — the original had no formatting applied.

## Backend or frontend?
Backend (Python docs tooling).