### PR TITLE
chore: release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Charted will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-06-18
+
+### Fixed
+- AreaChart stacked rendering: the top cumulative series was drawing over the
+  lower bands, making a stacked area appear as a single colour. Bands now
+  render correctly with each layer visible.
+- Histogram x-axis: tick labels were missing and bars were positioned ordinally
+  instead of spanning their exact bin width. Bars now cover their precise bin
+  range and align to the edge ticks.
+- X-axis tick labels clipped at the bottom edge of charts: the layout now
+  reserves the full tick-label band. Gantt and time-scale charts also register
+  their x-axis labels for layout so labels are never cut off.
+
+### Docs
+- Redesigned the charted.mrzk.io landing page and documentation theme, rebuilt
+  the gallery with all 14 chart types, and added a social preview (OG) image.
+
 ## [1.2.0] - 2026-06-17
 
 ### Added

--- a/charted/__init__.py
+++ b/charted/__init__.py
@@ -6,7 +6,7 @@ try:
     __version__ = version("charted")
 except PackageNotFoundError:
     # Running from a source checkout without an installed distribution.
-    __version__ = "1.2.0"
+    __version__ = "1.2.1"
 
 from .charts import (
     AreaChart,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "charted"
 copyright = "2024, Andryo Marzuki"
 author = "Andryo Marzuki"
-release = "1.0.5"
+release = "1.2.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charted"
-version = "1.2.0"
+version = "1.2.1"
 description = "Charted is a zero dependency SVG chart generator that aims to provide a simple interface for generating beautiful and customisable graphs. This project is inspired by chart libraries like mermaid.js."
 authors = [{ name = "Andryo Marzuki", email = "andryo@mrzk.io" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Prepares the 1.2.1 patch release. Bumps the version in all three locations and adds the CHANGELOG entry covering the changes merged to main since v1.2.0.

## Files changed

- `pyproject.toml` — version 1.2.0 -> 1.2.1
- `charted/__init__.py` — fallback `__version__` 1.2.0 -> 1.2.1
- `docs/conf.py` — stale release string 1.0.5 -> 1.2.1
- `CHANGELOG.md` — new `## [1.2.1] - 2026-06-18` entry

## CHANGELOG entry

### Fixed
- AreaChart stacked rendering: the top cumulative series was drawing over the lower bands, making a stacked area appear as a single colour. Bands now render correctly with each layer visible.
- Histogram x-axis: tick labels were missing and bars were positioned ordinally instead of spanning their exact bin width. Bars now cover their precise bin range and align to the edge ticks.
- X-axis tick labels clipped at the bottom edge of charts: the layout now reserves the full tick-label band. Gantt and time-scale charts also register their x-axis labels for layout so labels are never cut off.

### Docs
- Redesigned the charted.mrzk.io landing page and documentation theme, rebuilt the gallery with all 14 chart types, and added a social preview (OG) image.

## Tests

- ruff check: all checks passed
- pytest (excluding benchmarks): 1518 passed, 7 skipped in 12.65s -- no failures

## Verification

No behaviour change. Version strings confirmed consistent across pyproject.toml, charted/__init__.py, and docs/conf.py. CHANGELOG entry verified against git log since v1.2.0 (PRs #92-#97).

## Scope notes

docs/conf.py `release` was stale at 1.0.5; corrected to 1.2.1 in this PR. Future releases should keep this in sync.

DO NOT tag or create a GitHub release from this PR -- the orchestrator handles that step.

## Backend or frontend?

backend