### PR TITLE
docs: lead with uv as primary install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Zero-dependency charts for Python and AI agents. SVG and PNG, 15 chart types, a 
 ## Quickstart
 
 ```sh
+uv add charted
+```
+
+Or with pip:
+
+```sh
 pip install charted
 ```
 
@@ -712,16 +718,40 @@ md = chart.to_markdown()
 
 ## Installation
 
+**Library (use in your code):**
+
+```sh
+uv add charted
+```
+
+Or with pip:
+
 ```sh
 pip install charted
 ```
 
+**CLI or MCP server (standalone tool, no project install needed):**
+
+```sh
+uvx charted ...
+# or
+pipx install charted
+```
+
+> Note: a `uvx`/`pipx`-installed package runs in its own isolated environment and cannot be imported into your project code. Use `uv add` or `pip install` when you want to `import charted` in your scripts.
+
 Optional extras (these add dependencies, the core library stays zero-dep):
 ```sh
-pip install 'charted[png]'     # PNG export via cairosvg
-pip install 'charted[mcp]'     # MCP server for AI agent integration
-pip install 'charted[duckdb]'  # generate charts from SQL queries
-pip install 'charted[dev]'     # dev tools including PNG visual testing
+uv add "charted[png]"     # PNG export via cairosvg
+uv add "charted[mcp]"     # MCP server for AI agent integration
+uv add "charted[duckdb]"  # generate charts from SQL queries
+uv add "charted[dev]"     # dev tools including PNG visual testing
+
+# pip equivalents
+pip install 'charted[png]'
+pip install 'charted[mcp]'
+pip install 'charted[duckdb]'
+pip install 'charted[dev]'
 ```
 
 ## PNG Export
@@ -744,17 +774,18 @@ PNG export requires `cairosvg`. If it's not installed, `save()` raises a helpful
 Charted includes an MCP server so AI agents (Claude Code, Cursor, etc.) can generate charts without writing Python:
 
 ```sh
-# Register with Claude Code
-claude mcp add charted -- charted-mcp
-
-# Or run standalone (no install step)
+# Run standalone (no install step, recommended)
 uvx --from 'charted[mcp]' charted-mcp
 
-# Or after installing the extra
+# Or install the extra and run directly
+pip install 'charted[mcp]'
 charted-mcp
+
+# Register with Claude Code
+claude mcp add charted -- uvx --from 'charted[mcp]' charted-mcp
 ```
 
-Exposes tools: `create_chart`, `list_chart_types`, `list_themes`, `chart_from_csv`. Requires `pip install 'charted[mcp]'`.
+Exposes tools: `create_chart`, `list_chart_types`, `list_themes`, `chart_from_csv`. The `charted[mcp]` extra is required.
 
 `create_chart` and `chart_from_csv` take an `output_format` of `svg`, `html`, `data_url`, or `png`. With `output_format="png"` the tool returns a rasterized PNG image, so an agent can show the chart inline in a chat UI instead of relaying raw SVG markup. The `mcp` extra includes `cairosvg`, so PNG output works out of the box with the `uvx` command above. PNG rasterization needs cairo's system libraries; on Debian/Ubuntu install them with `apt install libcairo2`.
 

--- a/docs/_templates/landing.html
+++ b/docs/_templates/landing.html
@@ -47,7 +47,7 @@
       <h1 class="hero-headline">Charts worth&nbsp;publishing.</h1>
       <p class="hero-sub">Zero-dependency SVG charting for Python. No numpy, no pandas, no matplotlib. Pure stdlib. 15 chart types.</p>
       <div class="hero-install">
-        <code class="install-pill">pip install charted</code>
+        <code class="install-pill">uv add charted</code>
         <button class="copy-btn" onclick="copyInstall(this)" aria-label="Copy install command">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8">
             <rect x="5" y="5" width="9" height="9" rx="1.5"/>
@@ -330,7 +330,7 @@ chart.save(<span class="st">"combo.svg"</span>)</code></pre>
         </svg>
         <div>
           <strong>Zero runtime dependencies</strong>
-          <p>Pure Python stdlib. No numpy, pandas, or matplotlib. pip install and you're done.</p>
+          <p>Pure Python stdlib. No numpy, pandas, or matplotlib. Add with uv or pip and you're done.</p>
         </div>
       </div>
 
@@ -413,7 +413,7 @@ chart.save(<span class="st">"combo.svg"</span>)</code></pre>
   <div class="section-inner footer-inner">
     <div class="footer-top">
       <h2>Start in 30 seconds.</h2>
-      <code class="install-pill install-pill--dark">pip install charted</code>
+      <code class="install-pill install-pill--dark">uv add charted</code>
     </div>
     <nav class="footer-links">
       <a href="{{ pathto('quickstart', 1) }}">Docs</a>
@@ -428,7 +428,7 @@ chart.save(<span class="st">"combo.svg"</span>)</code></pre>
 
 <script>
 function copyInstall(btn) {
-  navigator.clipboard.writeText('pip install charted').then(function() {
+  navigator.clipboard.writeText('uv add charted').then(function() {
     btn.classList.add('copied');
     setTimeout(function() { btn.classList.remove('copied'); }, 1800);
   });

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,9 +4,27 @@ A 5-minute guide to creating beautiful SVG charts with zero dependencies.
 
 ## Installation
 
+**Library (use in your code):**
+
+```bash
+uv add charted
+```
+
+Or with pip:
+
 ```bash
 pip install charted
 ```
+
+**CLI or MCP server (standalone tool, no project install needed):**
+
+```bash
+uvx charted ...
+# or
+pipx install charted
+```
+
+> Note: packages installed via `uvx`/`pipx` run in isolation and cannot be imported into your project. Use `uv add` or `pip install` for library use.
 
 ## Quick Start
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -4,6 +4,22 @@ Create charts from the command line without writing Python code.
 
 ## Installation
 
+To run the CLI as a standalone tool (recommended, no project install needed):
+
+```bash
+uvx charted ...
+# or
+pipx install charted
+```
+
+To use the CLI inside a uv project:
+
+```bash
+uv add charted
+```
+
+Or with pip:
+
 ```bash
 pip install charted
 ```
@@ -158,6 +174,5 @@ charts:
 ```yaml
 - name: Generate Charts
   run: |
-    pip install charted
-    python -m charted batch ./data ./docs/images
+    uvx charted batch ./data ./docs/images
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,11 +4,27 @@ Get up and running with Charted in 5 minutes.
 
 ## Installation
 
+**Library (use in your code):**
+
+```bash
+uv add charted
+```
+
+Or with pip:
+
 ```bash
 pip install charted
 ```
 
 **Requirements:** Python 3.10+
+
+To run the CLI or MCP server as a standalone tool (no project install needed), use `uvx` or `pipx`:
+
+```bash
+uvx charted ...
+# or
+pipx install charted
+```
 
 ## Your First Chart
 
@@ -135,7 +151,10 @@ chart = BarChart(
 Create charts without writing Python:
 
 ```bash
-# From CSV
+# Using uvx (no install needed)
+uvx charted create bar sales.svg --data sales.csv
+
+# Using python -m (if charted is installed in your project)
 python -m charted create bar sales.svg --data sales.csv
 
 # Batch process


### PR DESCRIPTION
## Summary

Updates all install/quick-start surfaces so uv is the primary recommended method, with pip as a still-supported alternative, and uvx/pipx shown for the CLI and MCP server.

The distinction between library use and standalone tool use is now explicit throughout: `uv add` / `pip install` for importing charted in project code, and `uvx` / `pipx` for running the CLI or MCP server without adding it to a project.

## Files changed

- `README.md` (5 changed lines in Quickstart + Installation + MCP Server sections)
- `docs/quickstart.md` (Installation section rewritten, CLI section updated with uvx option)
- `docs/getting_started.md` (Installation section rewritten)
- `docs/guides/cli.md` (Installation section rewritten, GitHub Actions snippet uses uvx)
- `docs/_templates/landing.html` (both install pills switched to `uv add charted`, JS copy updated, zero-dep blurb updated)

## Exact new install snippets

**Library (primary):**
```sh
uv add charted
```

**Library (alternative):**
```sh
pip install charted
```

**CLI or MCP server (standalone):**
```sh
uvx charted ...
# or
pipx install charted
```

**MCP server (uvx, matches smithery.yaml):**
```sh
uvx --from 'charted[mcp]' charted-mcp
```

## Verification

- No em dashes added (checked all 5 files programmatically)
- `ruff check .`: All checks passed
- `sphinx-build -b html docs docs/_build/html`: build succeeded, 13 warnings (all pre-existing, no errors introduced)

## Scope notes

The `docs/index.rst` file contains only toctree directives and no install snippet, so it needed no changes.

The 13 sphinx warnings pre-exist on main and are unrelated to this PR (autodoc/cross-reference issues in chart type docs).

## Backend or frontend?

Frontend (documentation only). No runtime behaviour changed. No Playwright validation required.