### PR TITLE
fix(landing): reserve tallest-phrase height so the rotator never bumps the layout

### DIFF
--- a/docs/_templates/landing.html
+++ b/docs/_templates/landing.html
@@ -511,8 +511,26 @@ document.querySelectorAll('.reveal').forEach(function(el) { io.observe(el); });
     var size = Math.max(16, Math.min(38, (avail / (widest / 100)) * 0.98));
     headline.style.fontSize = size + 'px';
   }
-  window.addEventListener('resize', fit);
-  fit();
+
+  // Reserve the height of the TALLEST phrase at the current width, so the
+  // headline box never grows/collapses as phrases of different line counts
+  // cycle in and out (no vertical bump of the sub/CTA below it).
+  function reserveHeight() {
+    headline.style.minHeight = '';
+    var ph = head.textContent, pt = tail.textContent, tallest = 0;
+    for (var k = 0; k < phrases.length; k++) {
+      var b = phrases[k].lastIndexOf(' ') + 1;
+      head.textContent = phrases[k].slice(0, b);
+      tail.textContent = phrases[k].slice(b);
+      if (headline.offsetHeight > tallest) tallest = headline.offsetHeight;
+    }
+    head.textContent = ph; tail.textContent = pt;
+    headline.style.minHeight = tallest + 'px';
+  }
+
+  function relayout() { fit(); reserveHeight(); }
+  window.addEventListener('resize', relayout);
+  relayout();
 
   var typeMs = 55, deleteMs = 30, holdMs = 1100, gapMs = 240;
   var w = 0, i = 0, deleting = false;


### PR DESCRIPTION
Follow-up to #101 (which merged before this fix existed).

The headline height reserve only covered two lines, so cycling into the three-line "Reinventing the wheel for some reason." grew the box and bumped the sub/CTA down, then collapsed it back. Now it measures every phrase at the live width and reserves the tallest, recomputed on resize after the mobile font-fit. The box height is constant across the whole cycle.

Verified on the built page: the sub/install/CTA/chips sit at the same Y for the 2-line and 3-line phrases. JS-only, no Python/SVG touched.