### PR TITLE
fix(docs): dark-mode gallery contrast + dark chart variants + auto-mode palette

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -98,6 +98,48 @@ body[data-theme="dark"] {
   --color-admonition-title--tip:                #5fab9e;
 }
 
+/* ── AUTO MODE (no explicit toggle): follow the OS preference ────────────────── */
+/* The light block above uses body:not([data-theme="dark"]) as the default, which
+   also matches Furo's "auto" theme. Without this, auto + OS-dark got charted's
+   LIGHT text/sidebar vars over a dark page (scuffed text, light sidebar). Re-apply
+   the dark palette when the OS is dark and the user has not forced light. */
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) {
+    --color-background-primary:    #0f1a20;
+    --color-background-secondary:  #162028;
+    --color-background-hover:      #1e2d37;
+    --color-background-border:     #243040;
+
+    --color-foreground-primary:    #e8f0f4;
+    --color-foreground-secondary:  #8aacb8;
+    --color-foreground-muted:      #5a7888;
+    --color-foreground-border:     #2a3d4a;
+
+    --color-brand-primary:         #5fab9e;
+    --color-brand-content:         #f7dd72;
+    --color-brand-visited:         #f58b51;
+
+    --color-sidebar-background:    #0f1a20;
+    --color-sidebar-background-border: #243040;
+    --color-sidebar-link-text:     #8aacb8;
+    --color-sidebar-link-text--top-level: #e8f0f4;
+    --color-sidebar-item-background--hover: #1e2d37;
+    --color-sidebar-item-background--current: #1e2d37;
+
+    --color-code-background:       #162028;
+    --color-code-foreground:       #c9d4d9;
+
+    --color-admonition-title-background--note:    #5fab9e14;
+    --color-admonition-title--note:               #5fab9e;
+    --color-admonition-title-background--warning: #f7dd7214;
+    --color-admonition-title--warning:            #f7dd72;
+    --color-admonition-title-background--danger:  #db504a14;
+    --color-admonition-title--danger:             #db504a;
+    --color-admonition-title-background--tip:     #5fab9e14;
+    --color-admonition-title--tip:                #5fab9e;
+  }
+}
+
 /* ── HEADINGS ───────────────────────────────────────────────────────────────── */
 h1, h2, h3, h4, h5, h6 {
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
@@ -554,7 +596,7 @@ dl.field-list > dt {
   font-size: clamp(1.4rem, 2.5vw, 1.8rem);
   font-weight: 800;
   letter-spacing: -0.02em;
-  color: #2e4756;
+  color: var(--color-foreground-primary);
   border: none;
   margin: 0 0 0.5rem;
   padding: 0;
@@ -562,7 +604,7 @@ dl.field-list > dt {
 
 .gallery-light-header p {
   font-size: 0.95rem;
-  color: #5a7080;
+  color: var(--color-foreground-secondary);
   max-width: 52ch;
   margin: 0 auto;
 }
@@ -570,7 +612,7 @@ dl.field-list > dt {
 .charted-gallery-card-light {
   display: flex;
   flex-direction: column;
-  border: 1px solid #e8edf0;
+  border: 1px solid var(--color-background-border);
   border-radius: 8px;
   overflow: hidden;
   transition: box-shadow 0.2s;
@@ -582,7 +624,7 @@ dl.field-list > dt {
 }
 
 .charted-gallery-card-light .charted-gallery-img-wrap {
-  background: #f4f7f8;
+  background: var(--color-background-secondary);
   border-radius: 0;
 }
 
@@ -613,7 +655,7 @@ dl.field-list > dt {
 
 .charted-gallery-meta-light p {
   font-size: 0.8rem;
-  color: #5a7080;
+  color: var(--color-foreground-secondary);
   line-height: 1.5;
   margin: 0;
 }
@@ -628,3 +670,17 @@ dl.field-list > dt {
 }
 
 .charted-gallery-meta-light a:hover { opacity: 1; }
+
+/* ── GALLERY CHART VARIANT SWAP ─────────────────────────────────────────────── */
+/* Each card ships both the light SVG and the dark SVG (#0f1a20 bg). Show the one
+   that matches the active theme. Selectors include img.<class> so they outrank the
+   generic ".charted-gallery-img-wrap img { display: block }" rule above. */
+.charted-gallery-card-light .charted-gallery-img-wrap img.gallery-img-dark { display: none; }
+
+body[data-theme="dark"] .charted-gallery-card-light .charted-gallery-img-wrap img.gallery-img-light { display: none; }
+body[data-theme="dark"] .charted-gallery-card-light .charted-gallery-img-wrap img.gallery-img-dark { display: block; }
+
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) .charted-gallery-card-light .charted-gallery-img-wrap img.gallery-img-light { display: none; }
+  body:not([data-theme="light"]) .charted-gallery-card-light .charted-gallery-img-wrap img.gallery-img-dark { display: block; }
+}

--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -15,7 +15,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_column.svg" alt="Column Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_column.svg" alt="Column Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_column.svg" alt="Column Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">ColumnChart</span>
@@ -26,7 +27,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_bar.svg" alt="Bar Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_bar.svg" alt="Bar Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_bar.svg" alt="Bar Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">BarChart</span>
@@ -37,7 +39,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_line.svg" alt="Line Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_line.svg" alt="Line Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_line.svg" alt="Line Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">LineChart</span>
@@ -48,7 +51,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_area.svg" alt="Area Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_area.svg" alt="Area Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_area.svg" alt="Area Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">AreaChart</span>
@@ -59,7 +63,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_scatter.svg" alt="Scatter Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_scatter.svg" alt="Scatter Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_scatter.svg" alt="Scatter Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">ScatterChart</span>
@@ -70,7 +75,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_bubble.svg" alt="Bubble Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_bubble.svg" alt="Bubble Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_bubble.svg" alt="Bubble Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">BubbleChart</span>
@@ -81,7 +87,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_pie.svg" alt="Pie Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_pie.svg" alt="Pie Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_pie.svg" alt="Pie Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">PieChart</span>
@@ -92,7 +99,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_radar.svg" alt="Radar Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_radar.svg" alt="Radar Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_radar.svg" alt="Radar Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">RadarChart</span>
@@ -103,7 +111,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_combo.svg" alt="Combo Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_combo.svg" alt="Combo Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_combo.svg" alt="Combo Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">ComboChart</span>
@@ -114,7 +123,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_heatmap.svg" alt="Heatmap" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_heatmap.svg" alt="Heatmap" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_heatmap.svg" alt="Heatmap" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">HeatmapChart</span>
@@ -125,7 +135,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_gantt.svg" alt="Gantt Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_gantt.svg" alt="Gantt Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_gantt.svg" alt="Gantt Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">GanttChart</span>
@@ -136,7 +147,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_histogram.svg" alt="Histogram" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_histogram.svg" alt="Histogram" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_histogram.svg" alt="Histogram" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">Histogram</span>
@@ -147,7 +159,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_polar.svg" alt="Polar Area Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_polar.svg" alt="Polar Area Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_polar.svg" alt="Polar Area Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">PolarAreaChart</span>
@@ -158,7 +171,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_boxplot.svg" alt="Box Plot" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_boxplot.svg" alt="Box Plot" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_boxplot.svg" alt="Box Plot" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">BoxPlot</span>
@@ -169,7 +183,8 @@ charted itself from real-ish datasets. No screenshots, no stubs.
 
        <div class="charted-gallery-card-light">
          <div class="charted-gallery-img-wrap">
-           <img src="_static/landing/gallery_light_sankey.svg" alt="Sankey Chart" loading="lazy" />
+           <img class="gallery-img-light" src="_static/landing/gallery_light_sankey.svg" alt="Sankey Chart" loading="lazy" />
+           <img class="gallery-img-dark" src="_static/landing/gallery_sankey.svg" alt="Sankey Chart" loading="lazy" />
          </div>
          <div class="charted-gallery-meta-light">
            <span class="charted-gallery-type-light">SankeyChart</span>


### PR DESCRIPTION
Fixes three dark-mode issues on the docs (reported with screenshots).

### 1. Scuffed gallery text
The gallery section header ("15 chart types. All dogfooded.") and card text hardcoded light-mode hex (#2e4756, #5a7080), so they rendered dark-on-dark in dark mode. Now they use the Furo theme vars (--color-foreground-primary/secondary, --color-background-border/secondary) and adapt automatically.

### 2. Charts not dark in dark mode
Gallery cards always showed the light SVGs. Each card now ships BOTH the light and the dark variant (the dark gallery_*.svg set, #0f1a20 bg, already generated) and CSS shows the one matching the active theme. No regeneration, no svg-diff impact.

### 3. Light sidebar / scuffed native text in AUTO mode
The light-var selector body:not([data-theme="dark"]) also matches Furo's "auto" theme, so when the OS was dark, charted's LIGHT text + sidebar vars were forced over a dark page (the half-state in the report: dark bg, light sidebar, dark text). Added an @media (prefers-color-scheme: dark) block that re-applies the dark palette for non-explicit-light, so auto mode matches explicit dark.

### Validated
Built with sphinx-build; screenshotted gallery in forced-dark and forced-light. Dark: header/card text readable, charts swapped to dark variants. Light: unchanged (no regression). Touches only custom.css + gallery.rst. No Python, no SVGs regenerated.
