### PR TITLE
feat: SEO hardening (canonical, robots, sitemap, JSON-LD, colours cross-link)

### DIFF
--- a/docs/_extra/robots.txt
+++ b/docs/_extra/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://charted.mrzk.io/sitemap.xml

--- a/docs/_extra/sitemap.xml
+++ b/docs/_extra/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://charted.mrzk.io/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://charted.mrzk.io/quickstart.html</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://charted.mrzk.io/getting_started.html</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://charted.mrzk.io/gallery.html</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/bar.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/column.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/line.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/area.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/scatter.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/bubble.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/pie.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/radar.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/combo.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/heatmap.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/gantt.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/histogram.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/polar_area.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/charts/boxplot.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://charted.mrzk.io/guides/cli.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://charted.mrzk.io/guides/theming.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://charted.mrzk.io/guides/configuration.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://charted.mrzk.io/guides/interactivity.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://charted.mrzk.io/api/charts.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://charted.mrzk.io/api/themes.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+</urlset>

--- a/docs/_templates/landing.html
+++ b/docs/_templates/landing.html
@@ -16,7 +16,40 @@
   <meta name="twitter:title" content="charted: Charts worth publishing" />
   <meta name="twitter:description" content="Zero-dependency SVG charts for Python. 15 chart types, no numpy, no pandas, no matplotlib." />
   <meta name="twitter:image" content="https://charted.mrzk.io/_static/og-image.png" />
+  <meta name="author" content="Andryo Marzuki" />
+  <link rel="canonical" href="https://charted.mrzk.io/" />
   <link rel="icon" href="{{ pathto('_static/images/charted-icon.svg', 1) }}" type="image/svg+xml" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Person",
+        "@id": "https://mrzk.io/#person",
+        "name": "Andryo Marzuki",
+        "url": "https://mrzk.io",
+        "sameAs": [
+          "https://github.com/marzukia",
+          "https://www.linkedin.com/in/andryomarzuki/"
+        ]
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "charted",
+        "url": "https://charted.mrzk.io",
+        "description": "Zero-dependency SVG charting for Python. 15 chart types. No numpy, no pandas, no matplotlib. Pure stdlib.",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "author": { "@id": "https://mrzk.io/#person" }
+      }
+    ]
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -423,8 +456,9 @@ chart.save(<span class="st">"combo.svg"</span>)</code></pre>
       <a href="https://github.com/marzukia/charted" target="_blank" rel="noopener">GitHub</a>
       <a href="https://pypi.org/project/charted/" target="_blank" rel="noopener">PyPI</a>
       <a href="https://github.com/marzukia/charted/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
+      <a href="https://colours.mrzk.io" target="_blank" rel="noopener">colours</a>
     </nav>
-    <p class="footer-copy">MIT License &middot; Built by <a href="https://mrzk.io" target="_blank" rel="noopener">Andryo Marzuki</a></p>
+    <p class="footer-copy">MIT License &middot; Built by <a href="https://mrzk.io" target="_blank" rel="noopener">Andryo Marzuki</a> &middot; Also: <a href="https://colours.mrzk.io" target="_blank" rel="noopener">colours</a></p>
   </div>
 </footer>
 

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -2,6 +2,8 @@
 
 {% block extrahead %}
   {{ super() }}
+  <meta name="author" content="Andryo Marzuki" />
+  {% if pageurl %}<link rel="canonical" href="{{ pageurl }}" />{% endif %}
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://charted.mrzk.io/{{ pagename }}.html" />
   <meta property="og:title" content="{{ title|striptags }} | charted" />

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "furo"
 html_static_path = ["_static"]
+html_extra_path = ["_extra"]
 html_title = "charted"
 html_logo = "_static/images/charted-icon.svg"
 html_favicon = "_static/images/charted-icon.svg"


### PR DESCRIPTION
Fixes the audited gaps: canonical on the landing page, robots.txt + sitemap.xml (html_extra_path), Person+SoftwareApplication JSON-LD (Andryo Marzuki, sameAs github+linkedin — same @id as colours/blog so Google unifies the entity), author meta, and a colours.mrzk.io cross-link. Validated with a real sphinx-build (clean). Minimal + additive.