### PR TITLE
fix: correct LogScale.ticks() to only return minor ticks for true sub-decade ranges

### DIFF
--- a/charted/charts/chart.py
+++ b/charted/charts/chart.py
@@ -675,7 +675,7 @@ class Chart(
                 fill="none",
             )
             children.append(border_path)
-            
+
             # Add top and right edges at gridline weight for full frame
             # This frames the plot area when data peaks near the top edge
             # Using gridline color (#CCCCCC) and width (1) for subtle framing

--- a/charted/charts/scales.py
+++ b/charted/charts/scales.py
@@ -129,11 +129,14 @@ class LogScale(Scale):
 
     def ticks(self) -> list[float]:
         """Return tick positions for a log scale, including minor ticks.
-        
+
         For sub-decade ranges where no power of ten exists within the domain,
         return minor ticks at m * 10^n for m in 1..9. This ensures useful
-        intermediate ticks for ranges like 28-55 (30, 40, 50) or 386-705 
+        intermediate ticks for ranges like 28-55 (30, 40, 50) or 386-705
         (400, 500, 600, 700).
+
+        For full-decade ranges (e.g., 1-1000), return only powers of ten
+        to preserve existing behavior and avoid overly dense axes.
         """
         if self.max_value == self.min_value:
             # Single positive point / all-equal positive series: pad to the
@@ -143,35 +146,35 @@ class LogScale(Scale):
             if hi == lo:
                 hi = lo * 10
             return [int(lo) if lo >= 1 else lo, int(hi) if hi >= 1 else hi]
-        
+
         lo = math.floor(self._log_min)
         hi = math.ceil(self._log_max)
-        ticks: list[float] = []
-        
-        # Try to collect minor ticks (m * 10^n for m in 1..9)
-        for exp in range(lo, hi + 1):
-            base = 10 ** exp
-            for m in range(1, 10):
-                value = m * base
-                if self.min_value <= value <= self.max_value:
-                    # Present clean integers where possible.
-                    ticks.append(int(value) if exp >= 0 else value)
-        
-        # If we found minor ticks, return them (filtered to domain)
-        if ticks:
-            return ticks
-        
-        # Fallback: try powers of ten within domain (original behavior)
+
+        # First, collect powers of ten within the domain (original behavior)
         powers: list[float] = []
         for exp in range(lo, hi + 1):
             value = 10**exp
             if self.min_value <= value <= self.max_value:
                 powers.append(int(value) if exp >= 0 else value)
-        
-        # Ultimate fallback: endpoints
-        if not powers:
-            powers = [self.min_value, self.max_value]
-        return powers
+
+        # If we have powers of ten, return only those (full-decade case)
+        if powers:
+            return powers
+
+        # No powers of ten in domain: this is a true sub-decade range.
+        # Return minor ticks (m * 10^n for m in 1..9) filtered to domain.
+        ticks: list[float] = []
+        for exp in range(lo, hi + 1):
+            base = 10**exp
+            for m in range(1, 10):
+                value = m * base
+                if self.min_value <= value <= self.max_value:
+                    ticks.append(int(value) if exp >= 0 else value)
+
+        # Ultimate fallback: endpoints (should rarely hit)
+        if not ticks:
+            ticks = [self.min_value, self.max_value]
+        return ticks
 
 
 def _to_epoch(value: TimeValue) -> float:

--- a/tests/charts/test_log_scale_ticks.py
+++ b/tests/charts/test_log_scale_ticks.py
@@ -1,6 +1,5 @@
 """Test LogScale ticks for sub-decade ranges."""
 
-import pytest
 from charted.charts.scales import LogScale
 
 
@@ -8,35 +7,32 @@ def test_log_scale_sub_decade_range_28_55():
     """Test that sub-decade range 28-55 returns minor ticks (30, 40, 50)."""
     scale = LogScale(28, 55)
     ticks = scale.ticks()
-    # Should return minor ticks at 30, 40, 50
-    assert 30 in ticks
-    assert 40 in ticks
-    assert 50 in ticks
-    # Should not fall back to just endpoints
-    assert len(ticks) >= 3
+    # Should return minor ticks at 30, 40, 50 (no power of 10 in range)
+    assert ticks == [30, 40, 50]
 
 
 def test_log_scale_sub_decade_range_386_705():
     """Test that sub-decade range 386-705 returns minor ticks (400, 500, 600, 700)."""
     scale = LogScale(386, 705)
     ticks = scale.ticks()
-    # Should return minor ticks at 400, 500, 600, 700
-    assert 400 in ticks
-    assert 500 in ticks
-    assert 600 in ticks
-    assert 700 in ticks
-    # Should not fall back to just endpoints
-    assert len(ticks) >= 4
+    # Should return minor ticks at 400, 500, 600, 700 (no power of 10 in range)
+    assert ticks == [400, 500, 600, 700]
 
 
-def test_log_scale_full_decade_range():
-    """Test that full decade range still returns powers of ten."""
+def test_log_scale_full_decade_range_returns_only_powers():
+    """Test that full decade range returns ONLY powers of ten, no minor ticks."""
+    scale = LogScale(1, 1000)
+    ticks = scale.ticks()
+    # Should return ONLY powers: [1, 10, 100, 1000], NOT minor ticks
+    assert ticks == [1, 10, 100, 1000]
+    assert len(ticks) == 4  # Critical: no minor ticks for full decades
+
+
+def test_log_scale_full_decade_range_10_1000():
+    """Test another full decade range."""
     scale = LogScale(10, 1000)
     ticks = scale.ticks()
-    # Should return powers of ten: 10, 100, 1000
-    assert 10 in ticks
-    assert 100 in ticks
-    assert 1000 in ticks
+    assert ticks == [10, 100, 1000]
 
 
 def test_log_scale_single_point():
@@ -44,6 +40,44 @@ def test_log_scale_single_point():
     scale = LogScale(50, 50)
     ticks = scale.ticks()
     # Should return bracketing decade: 10, 100
-    assert len(ticks) == 2
-    assert min(ticks) == 10
-    assert max(ticks) == 100
+    assert ticks == [10, 100]
+
+
+def test_log_scale_negative_exponents():
+    """Test ranges with negative exponents (0 < x < 1)."""
+    import pytest
+
+    # Range that includes a power of ten (0.1 = 10^-1)
+    scale_with_power = LogScale(0.1, 0.5)
+    ticks_with_power = scale_with_power.ticks()
+    # Contains 0.1 (power of 10), so returns only that power
+    assert ticks_with_power == [0.1]
+
+    # True sub-decade with negative exponents: no power of 10 in range
+    scale_sub_decade = LogScale(0.15, 0.5)
+    ticks_sub_decade = scale_sub_decade.ticks()
+    # No power of 10 in [0.15, 0.5], returns minor ticks
+    # Note: floating point precision may cause 0.3 to be 0.30000000000000004
+    assert len(ticks_sub_decade) == 4  # 0.2, 0.3, 0.4, 0.5
+    assert 0.2 in ticks_sub_decade
+    assert pytest.approx(0.3) in ticks_sub_decade or any(
+        abs(t - 0.3) < 1e-10 for t in ticks_sub_decade
+    )
+    assert 0.4 in ticks_sub_decade
+    assert 0.5 in ticks_sub_decade
+
+
+def test_log_scale_crosses_decade_boundary():
+    """Test range that includes a power of ten (full-decade behavior)."""
+    scale = LogScale(5, 50)
+    ticks = scale.ticks()
+    # Contains 10, so returns ONLY powers: [10]
+    assert ticks == [10]
+
+
+def test_log_scale_just_below_decade():
+    """Test range just below a decade boundary."""
+    scale = LogScale(2, 8)
+    ticks = scale.ticks()
+    # No power of 10 in [2, 8], returns minor ticks
+    assert ticks == [2, 3, 4, 5, 6, 7, 8]


### PR DESCRIPTION
Fixed bug where full-decade ranges (e.g., 1-1000) incorrectly returned all minor ticks (28 values) instead of only powers of ten (4 values).

- LogScale.ticks() now correctly returns minor ticks ONLY when no power of ten exists in domain
- Added comprehensive tests for sub-decade, full-decade, and edge cases
- All CI checks pass